### PR TITLE
Add prysm arm64 building

### DIFF
--- a/.github/workflows/prysm-image-rebuild.yml
+++ b/.github/workflows/prysm-image-rebuild.yml
@@ -1,0 +1,71 @@
+name: 'Prysm Images Rebuild'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Exiting Prysm version to build'
+        required: true
+
+jobs:
+  build-beacon-chain:
+    if: github.repository_owner == 'NethermindEth'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: docker/prysm/
+          file: Dockerfile.beacon
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: nethermindeth/prysm-beacon-chain:${{ github.event.inputs.version }}
+
+  build-validator:
+    if: github.repository_owner == 'NethermindEth'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: docker/prysm/
+          file: Dockerfile.validator
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: nethermindeth/prysm-validator:${{ github.event.inputs.version }}
+
+

--- a/.github/workflows/prysm-image-rebuild.yml
+++ b/.github/workflows/prysm-image-rebuild.yml
@@ -36,6 +36,7 @@ jobs:
           file: Dockerfile.beacon
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: VERSION=${{ github.event.inputs.version }}
           tags: nethermindeth/prysm-beacon-chain:${{ github.event.inputs.version }}
 
   build-validator:
@@ -66,6 +67,7 @@ jobs:
           file: Dockerfile.validator
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: VERSION=${{ github.event.inputs.version }}
           tags: nethermindeth/prysm-validator:${{ github.event.inputs.version }}
 
 

--- a/docker/prysm/Dockerfile.beacon
+++ b/docker/prysm/Dockerfile.beacon
@@ -1,0 +1,13 @@
+FROM debian:bullseye-20221004
+
+ARG TARGETPLATFORM
+ARG VERSION
+
+RUN apt update -y && apt install -y wget
+
+ADD downloader.sh .
+RUN chmod +x downloader.sh
+
+RUN ./downloader.sh beacon-chain
+
+ENTRYPOINT ["/app/cmd/beacon-chain/beacon-chain"]

--- a/docker/prysm/Dockerfile.validator
+++ b/docker/prysm/Dockerfile.validator
@@ -1,0 +1,13 @@
+FROM debian:bullseye-20221004
+
+ARG TARGETPLATFORM
+ARG VERSION
+
+RUN apt update -y && apt install -y wget
+
+ADD downloader.sh .
+RUN chmod +x downloader.sh
+
+RUN ./downloader.sh validator
+
+ENTRYPOINT ["/app/cmd/validator/validator"]

--- a/docker/prysm/build-beacon.sh
+++ b/docker/prysm/build-beacon.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+set -x
+
+VERSION=${1}
+
+docker buildx build --progress=plain --platform=linux/amd64,linux/arm64 --build-arg VERSION="${VERSION}" -t nethermindeth/prysm-beacon-chain:"${VERSION}" --push -f Dockerfile.beacon --push .

--- a/docker/prysm/build-validator.sh
+++ b/docker/prysm/build-validator.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+set -x
+
+VERSION=${1}
+
+docker buildx build --progress=plain --platform=linux/amd64,linux/arm64 --build-arg VERSION="${VERSION}" -t nethermindeth/prysm-validator:"${VERSION}" --push -f Dockerfile.validator --push .

--- a/docker/prysm/downloader.sh
+++ b/docker/prysm/downloader.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+set -x
+
+EXECUTABLE=${1}
+echo "VERSION, ${VERSION}"
+echo "TARGETPLATFORM, ${TARGETPLATFORM}"
+
+
+wget -q https://github.com/prysmaticlabs/prysm/releases/download/${VERSION}/${EXECUTABLE}-${VERSION}-${TARGETPLATFORM/\//\-}
+wget -q https://github.com/prysmaticlabs/prysm/releases/download/${VERSION}/${EXECUTABLE}-${VERSION}-${TARGETPLATFORM/\//\-}.sha256
+ls -la .
+sha256sum -c ${EXECUTABLE}-${VERSION}-${TARGETPLATFORM/\//\-}.sha256
+
+mkdir -p /app/cmd/${EXECUTABLE}/
+mv ${EXECUTABLE}-${VERSION}-${TARGETPLATFORM/\//\-} /app/cmd/${EXECUTABLE}/${EXECUTABLE}
+
+chmod +x /app/cmd/${EXECUTABLE}/${EXECUTABLE}

--- a/docker/prysm/downloader.sh
+++ b/docker/prysm/downloader.sh
@@ -4,17 +4,18 @@ IFS=$'\n\t'
 
 set -x
 
-EXECUTABLE=${1}
+EXECUTABLE_NAME=${1}
+EXECUTABLE_FULL_NAME=${EXECUTABLE_NAME}-${VERSION}-${TARGETPLATFORM/\//\-}
 echo "VERSION, ${VERSION}"
 echo "TARGETPLATFORM, ${TARGETPLATFORM}"
 
 
-wget -q https://github.com/prysmaticlabs/prysm/releases/download/${VERSION}/${EXECUTABLE}-${VERSION}-${TARGETPLATFORM/\//\-}
-wget -q https://github.com/prysmaticlabs/prysm/releases/download/${VERSION}/${EXECUTABLE}-${VERSION}-${TARGETPLATFORM/\//\-}.sha256
+wget -q https://github.com/prysmaticlabs/prysm/releases/download/"${VERSION}"/"${EXECUTABLE_FULL_NAME}"
+wget -q https://github.com/prysmaticlabs/prysm/releases/download/"${VERSION}"/"${EXECUTABLE_FULL_NAME}".sha256
 ls -la .
-sha256sum -c ${EXECUTABLE}-${VERSION}-${TARGETPLATFORM/\//\-}.sha256
+sha256sum -c "${EXECUTABLE_FULL_NAME}".sha256
 
-mkdir -p /app/cmd/${EXECUTABLE}/
-mv ${EXECUTABLE}-${VERSION}-${TARGETPLATFORM/\//\-} /app/cmd/${EXECUTABLE}/${EXECUTABLE}
+mkdir -p /app/cmd/"${EXECUTABLE_NAME}"/
+mv "${EXECUTABLE_FULL_NAME}" /app/cmd/"${EXECUTABLE_NAME}"/"${EXECUTABLE_NAME}"
 
-chmod +x /app/cmd/${EXECUTABLE}/${EXECUTABLE}
+chmod +x /app/cmd/"${EXECUTABLE_NAME}"/"${EXECUTABLE_NAME}"


### PR DESCRIPTION
Default prysm docker image does not support linux/arm64. This is wrapper around built executables to package it as docker image.