### PR TITLE
Adding NLB service for geth RPC port

### DIFF
--- a/charts/execution-beacon/templates/service-rpc-nlb-geth.yaml
+++ b/charts/execution-beacon/templates/service-rpc-nlb-geth.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.geth.rpcSVCNLB.enabled -}}
+{{- range $i, $e := until (int .Values.global.replicaCount) }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" $ }}-nlb-{{ $i }}
+  labels:
+    {{- include "common.labels.standard" $ | nindent 4 }}
+    pod: "{{ include "common.names.fullname" $ }}-{{ $i }}"
+    type: rpc-nlb
+  {{- with $.Values.geth.rpcSVCNLB.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ $.Values.geth.rpcSVCNLB.type }}
+  externalTrafficPolicy: Local
+  ports:
+    - name: rpc-tcp
+      port: {{ $.Values.geth.rpcSVCNLB.port }}
+      protocol: TCP
+      targetPort: {{ $.Values.geth.rpcSVCNLB.port }}
+  selector:
+    {{- include "common.labels.matchLabels" $ | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: "{{ include "common.names.fullname" $ }}-{{ $i }}"
+  {{- with $.Values.geth.rpcSVCNLB.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -501,6 +501,13 @@ geth:
       port: sidecar
       scheme: HTTP
 
+  rpcSVCNLB:
+    enabled: false
+    type: LoadBalancer
+    port: 8545
+    annotations: {}
+    loadBalancerSourceRanges: []
+  
 
 nethermind:
   enabled: false


### PR DESCRIPTION
This will allow NLB service to be created for geth RPC port.