### PR TITLE
Add envFrom to execution container 

### DIFF
--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -121,6 +121,11 @@ spec:
         - name: execution
           image: "{{ (pluck .Values.execution.client .Values.global.image.execution | first ).repository }}:{{ (pluck .Values.execution.client .Values.global.image.execution | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
+          {{- if .Values.global.externalSecrets.enabled }}
+          envFrom:
+            - secretRef:
+                name: eso-{{ include "common.names.fullname" . }}
+          {{- end }}
           command:
             - sh
             - -ac

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -133,9 +133,7 @@ spec:
               {{- if .Values.global.p2pNodePort.enabled }}
               . /env/init-nodeport;
               {{- end }}
-            {{/*
-            Configuration for Nethermind execution client
-            */}}
+            {{- /* Configuration for Nethermind execution client */}}
             {{- if eq .Values.execution.client "nethermind" }}
               exec /nethermind/Nethermind.Runner
             {{- if eq .Values.global.network "gnosis" }}
@@ -175,13 +173,6 @@ spec:
               --Metrics.ExposePort={{ .Values.execution.metrics.port }}
               --Metrics.NodeName=$POD_NAME
             {{- end }}
-            {{- if .Values.execution.seq.enabled }}
-              --Seq.MinLevel={{ .Values.execution.seq.minLevel }}
-              --Seq.ServerUrl={{ .Values.execution.seq.serverUrl }}
-            {{- end }}
-            {{- if .Values.execution.mining.enabled }}
-              --Mining.ExtraData={{ .Values.execution.mining.extraData }}
-            {{- end }}
               --Network.MaxActivePeers={{ .Values.execution.targetPeers }}
             {{- if .Values.global.p2pNodePort.enabled }}
               --Network.ExternalIp=$EXTERNAL_IP
@@ -195,9 +186,7 @@ spec:
             {{- if .Values.execution.terminalTotalDifficulty }}
               --Merge.TerminalTotalDifficulty={{ .Values.execution.terminalTotalDifficulty }}
             {{- end }}
-            {{/*
-            Configuration for Geth execution client
-            */}}
+            {{- /* Configuration for Geth execution client */}}
             {{- else if eq .Values.execution.client "geth" }}
               exec geth
               --syncmode=snap
@@ -243,9 +232,7 @@ spec:
               --metrics.port={{ .Values.execution.metrics.port }}
               --metrics.addr={{ .Values.execution.metrics.host }}  
             {{- end }}
-            {{/*
-            Configuration for Besu execution client
-            */}}
+            {{- /* Configuration for Besu execution client */}}
             {{- else if eq .Values.execution.client "besu" }}
               exec /opt/besu/bin/besu
               --network={{ .Values.global.network }}
@@ -272,9 +259,7 @@ spec:
               --metrics.port={{ .Values.execution.metrics.port }}
               --metrics.addr={{ .Values.execution.metrics.host }}  
             {{- end }}
-            {{/*
-            Configuration for Erigon execution client
-            */}}
+            {{- /* Configuration for Erigon execution client */}}
             {{- else if eq .Values.execution.client "erigon" }}
               exec erigon
               --datadir=/data/execution

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -175,6 +175,11 @@ spec:
               --Metrics.ExposePort={{ .Values.execution.metrics.port }}
               --Metrics.NodeName=$POD_NAME
             {{- end }}
+            {{- if .Values.execution.seq.enabled }}
+              --Seq.MinLevel={{ .Values.execution.seq.minLevel }}
+              --Seq.ServerUrl={{ .Values.execution.seq.serverUrl }}
+              --Mining.ExtraData={{ .Values.execution.seq.miningExtraData }}
+            {{- end }}
               --Network.MaxActivePeers={{ .Values.execution.targetPeers }}
             {{- if .Values.global.p2pNodePort.enabled }}
               --Network.ExternalIp=$EXTERNAL_IP

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -178,7 +178,9 @@ spec:
             {{- if .Values.execution.seq.enabled }}
               --Seq.MinLevel={{ .Values.execution.seq.minLevel }}
               --Seq.ServerUrl={{ .Values.execution.seq.serverUrl }}
-              --Mining.ExtraData={{ .Values.execution.seq.miningExtraData }}
+            {{- end }}
+            {{- if .Values.execution.mining.enabled }}
+              --Mining.ExtraData={{ .Values.execution.mining.extraData }}
             {{- end }}
               --Network.MaxActivePeers={{ .Values.execution.targetPeers }}
             {{- if .Values.global.p2pNodePort.enabled }}

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -302,11 +302,22 @@ execution:
   ## -------------------------- Execution node specific settings -----------------------------------------
   # Manually specify TerminalTotalDifficulty, overriding the bundled setting
   terminalTotalDifficulty: ""
+  
+  ## -------------------------- Nethermind specific settings -----------------------------------------
+  ## Seq logging
   seq:
-    enabled: true
+    enabled: false
     minLevel: ""
     serverUrl: ""
-    miningExtraData: ""
+
+  ## -------------------------- Nethermind specific settings -----------------------------------------
+  ## Fields to override in nethermind config
+  mining:
+    enabled: false
+    extraData: ""
+
+  ## -------------------------- Nethermind specific settings -----------------------------------------
+  ## JsonRpc settings to override in nethermind config
   jsonrpc:
     enabled: true
     namespaces:

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -302,22 +302,7 @@ execution:
   ## -------------------------- Execution node specific settings -----------------------------------------
   # Manually specify TerminalTotalDifficulty, overriding the bundled setting
   terminalTotalDifficulty: ""
-  
-  ## -------------------------- Nethermind specific settings -----------------------------------------
-  ## Seq logging
-  seq:
-    enabled: false
-    minLevel: ""
-    serverUrl: ""
 
-  ## -------------------------- Nethermind specific settings -----------------------------------------
-  ## Fields to override in nethermind config
-  mining:
-    enabled: false
-    extraData: ""
-
-  ## -------------------------- Nethermind specific settings -----------------------------------------
-  ## JsonRpc settings to override in nethermind config
   jsonrpc:
     enabled: true
     namespaces:

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -302,7 +302,11 @@ execution:
   ## -------------------------- Execution node specific settings -----------------------------------------
   # Manually specify TerminalTotalDifficulty, overriding the bundled setting
   terminalTotalDifficulty: ""
-
+  seq:
+    enabled: true
+    minLevel: ""
+    serverUrl: ""
+    miningExtraData: ""
   jsonrpc:
     enabled: true
     namespaces:


### PR DESCRIPTION
### Description

We are not exporting some vars needed for execution client behavior, and with this fix, we should export these vars to the pods if we have set as enabled the external Secrets
We also added `seq` and `mining` fields under `execution` field. 