### PR TITLE
QS Audit, see PR for details/impacts

### DIFF
--- a/charts/dirk/templates/statefulset.yaml
+++ b/charts/dirk/templates/statefulset.yaml
@@ -80,7 +80,13 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}
@@ -105,7 +111,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}
@@ -150,7 +162,13 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}

--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -8,10 +8,10 @@ metadata:
 data:
   init.sh: |
     #!/bin/sh
-{{- if or (and .Values.execution.persistence.enabled .Values.execution.initChownData) (and .Values.beacon.persistence.enabled .Values.beacon.initChownData) (.Values.sharedPersistence.enabled) }}
-    mkdir -p /data && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data;
-    mkdir -p /data/beacon && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data/beacon;
-{{- end }}
+#{{- if or (and .Values.execution.persistence.enabled .Values.execution.initChownData) (and .Values.beacon.persistence.enabled .Values.beacon.initChownData) (.Values.sharedPersistence.enabled) }}
+    #mkdir -p /data && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data;
+    #mkdir -p /data/beacon && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data/beacon;
+#{{- end }}
     echo "Namespace: ${POD_NAMESPACE} Pod: ${POD_NAME}";
 {{- if .Values.global.p2pNodePort.enabled }}
   {{- if eq .Values.global.p2pNodePort.type "LoadBalancer" }}

--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -9,8 +9,8 @@ data:
   init.sh: |
     #!/bin/sh
 {{- if or (and .Values.execution.persistence.enabled .Values.execution.initChownData) (and .Values.beacon.persistence.enabled .Values.beacon.initChownData) (.Values.sharedPersistence.enabled) }}
-    mkdir -p /data && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data;
-    mkdir -p /data/beacon && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data/beacon;
+    mkdir -p /data && chown -R {{ .Values.global.podSecurityContext.runAsUser }}:{{ .Values.global.podSecurityContext.runAsUser }} /data;
+    mkdir -p /data/beacon && chown -R {{ .Values.global.podSecurityContext.runAsUser }}:{{ .Values.global.podSecurityContext.runAsUser }} /data/beacon;
 {{- end }}
     echo "Namespace: ${POD_NAMESPACE} Pod: ${POD_NAME}";
 {{- if .Values.global.p2pNodePort.enabled }}

--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -8,6 +8,10 @@ metadata:
 data:
   init.sh: |
     #!/bin/sh
+{{- if or (and .Values.execution.persistence.enabled .Values.execution.initChownData) (and .Values.beacon.persistence.enabled .Values.beacon.initChownData) (.Values.sharedPersistence.enabled) }}
+    mkdir -p /data && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data;
+    mkdir -p /data/beacon && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data/beacon;
+{{- end }}
     echo "Namespace: ${POD_NAMESPACE} Pod: ${POD_NAME}";
 {{- if .Values.global.p2pNodePort.enabled }}
     {{- if eq .Values.global.p2pNodePort.type "LoadBalancer" }}

--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -9,7 +9,7 @@ data:
   init.sh: |
     #!/bin/sh
 {{- if or (and .Values.execution.persistence.enabled .Values.execution.initChownData) (and .Values.beacon.persistence.enabled .Values.beacon.initChownData) (.Values.sharedPersistence.enabled) }}
-    mkdir -p /data && chown -R {{ .Values.global.podSecurityContext.runAsUser }}:{{ .Values.global.podSecurityContext.runAsUser }} /data;
+    # mkdir -p /data && chown -R {{ .Values.global.podSecurityContext.runAsUser }}:{{ .Values.global.podSecurityContext.runAsUser }} /data;
     mkdir -p /data/beacon && chown -R {{ .Values.global.podSecurityContext.runAsUser }}:{{ .Values.global.podSecurityContext.runAsUser }} /data/beacon;
 {{- end }}
     echo "Namespace: ${POD_NAMESPACE} Pod: ${POD_NAME}";

--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -8,32 +8,28 @@ metadata:
 data:
   init.sh: |
     #!/bin/sh
-#{{- if or (and .Values.execution.persistence.enabled .Values.execution.initChownData) (and .Values.beacon.persistence.enabled .Values.beacon.initChownData) (.Values.sharedPersistence.enabled) }}
-    #mkdir -p /data && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data;
-    #mkdir -p /data/beacon && chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.runAsUser }} /data/beacon;
-#{{- end }}
     echo "Namespace: ${POD_NAMESPACE} Pod: ${POD_NAME}";
 {{- if .Values.global.p2pNodePort.enabled }}
-  {{- if eq .Values.global.p2pNodePort.type "LoadBalancer" }}
-      until [ -n "$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do echo "Waiting for load balancer to get an IP" && sleep 10; done;
-      export EXTERNAL_EXECUTION_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
-      export EXTERNAL_BEACON_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
-      export EXTERNAL_IP=$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}');
-  {{- else }}
-      export EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
-      export EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
-      export EXTERNAL_IP=$(kubectl get nodes "${NODE_NAME}" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}');
-  {{- end }}
-      echo "EXTERNAL_EXECUTION_PORT=$EXTERNAL_EXECUTION_PORT" >  /env/init-nodeport;
-      echo "EXTERNAL_BEACON_PORT=$EXTERNAL_BEACON_PORT" >> /env/init-nodeport;
-      echo "EXTERNAL_IP=$EXTERNAL_IP"     >> /env/init-nodeport;
-      cat /env/init-nodeport;
-  {{- if eq .Values.beacon.client "prysm" }}
-      touch /data/beacon/config.yaml;
-      echo "p2p-host-ip: $EXTERNAL_IP" > /data/beacon/config.yaml;
-      echo "p2p-tcp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml;
-      echo "p2p-udp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml;
-      echo "Updated Prysm config.yaml file at /data/beacon/config.yaml";
-  {{- end }}
-      if [ -f "/data/beacon/config.yaml" ]; then echo "Beacon client config:" && cat "/data/beacon/config.yaml"; fi;
+    {{- if eq .Values.global.p2pNodePort.type "LoadBalancer" }}
+    until [ -n "$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do echo "Waiting for load balancer to get an IP" && sleep 10; done;
+    export EXTERNAL_EXECUTION_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+    export EXTERNAL_BEACON_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+    export EXTERNAL_IP=$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}');
+    {{- else }}
+    export EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+    export EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+    export EXTERNAL_IP=$(kubectl get nodes "${NODE_NAME}" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}');
+    {{- end }}
+    echo "EXTERNAL_EXECUTION_PORT=$EXTERNAL_EXECUTION_PORT" >  /env/init-nodeport;
+    echo "EXTERNAL_BEACON_PORT=$EXTERNAL_BEACON_PORT" >> /env/init-nodeport;
+    echo "EXTERNAL_IP=$EXTERNAL_IP"     >> /env/init-nodeport;
+    cat /env/init-nodeport;
+    {{- if eq .Values.beacon.client "prysm" }}
+    touch /data/beacon/config.yaml;
+    echo "p2p-host-ip: $EXTERNAL_IP" > /data/beacon/config.yaml;
+    echo "p2p-tcp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml;
+    echo "p2p-udp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml;
+    echo "Updated Prysm config.yaml file at /data/beacon/config.yaml";
+    {{- end }}
+    if [ -f "/data/beacon/config.yaml" ]; then echo "Beacon client config:" && cat "/data/beacon/config.yaml"; fi;
 {{- end }}

--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -14,26 +14,26 @@ data:
 {{- end }}
     echo "Namespace: ${POD_NAMESPACE} Pod: ${POD_NAME}";
 {{- if .Values.global.p2pNodePort.enabled }}
-    {{- if eq .Values.global.p2pNodePort.type "LoadBalancer" }}
-    until [ -n "$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do echo "Waiting for load balancer to get an IP" && sleep 10; done;
-    export EXTERNAL_EXECUTION_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
-    export EXTERNAL_BEACON_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
-    export EXTERNAL_IP=$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}');
-    {{- else }}
-    export EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
-    export EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
-    export EXTERNAL_IP=$(kubectl get nodes "${NODE_NAME}" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}');
-    {{- end }}
-    echo "EXTERNAL_EXECUTION_PORT=$EXTERNAL_EXECUTION_PORT" >  /env/init-nodeport;
-    echo "EXTERNAL_BEACON_PORT=$EXTERNAL_BEACON_PORT" >> /env/init-nodeport;
-    echo "EXTERNAL_IP=$EXTERNAL_IP"     >> /env/init-nodeport;
-    cat /env/init-nodeport;
-    {{- if eq .Values.beacon.client "prysm" }}
-    touch /data/beacon/config.yaml;
-    echo "p2p-host-ip: $EXTERNAL_IP" > /data/beacon/config.yaml;
-    echo "p2p-tcp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml;
-    echo "p2p-udp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml;
-    echo "Updated Prysm config.yaml file at /data/beacon/config.yaml";
-    {{- end }}
-    if [ -f "/data/beacon/config.yaml" ]; then echo "Beacon client config:" && cat "/data/beacon/config.yaml"; fi;
+  {{- if eq .Values.global.p2pNodePort.type "LoadBalancer" }}
+      until [ -n "$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do echo "Waiting for load balancer to get an IP" && sleep 10; done;
+      export EXTERNAL_EXECUTION_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+      export EXTERNAL_BEACON_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+      export EXTERNAL_IP=$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}');
+  {{- else }}
+      export EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+      export EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+      export EXTERNAL_IP=$(kubectl get nodes "${NODE_NAME}" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}');
+  {{- end }}
+      echo "EXTERNAL_EXECUTION_PORT=$EXTERNAL_EXECUTION_PORT" >  /env/init-nodeport;
+      echo "EXTERNAL_BEACON_PORT=$EXTERNAL_BEACON_PORT" >> /env/init-nodeport;
+      echo "EXTERNAL_IP=$EXTERNAL_IP"     >> /env/init-nodeport;
+      cat /env/init-nodeport;
+  {{- if eq .Values.beacon.client "prysm" }}
+      touch /data/beacon/config.yaml;
+      echo "p2p-host-ip: $EXTERNAL_IP" > /data/beacon/config.yaml;
+      echo "p2p-tcp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml;
+      echo "p2p-udp-port: $EXTERNAL_BEACON_PORT" >> /data/beacon/config.yaml;
+      echo "Updated Prysm config.yaml file at /data/beacon/config.yaml";
+  {{- end }}
+      if [ -f "/data/beacon/config.yaml" ]; then echo "Beacon client config:" && cat "/data/beacon/config.yaml"; fi;
 {{- end }}

--- a/charts/execution-beacon/templates/prometheusrules.yaml
+++ b/charts/execution-beacon/templates/prometheusrules.yaml
@@ -4,23 +4,23 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "common.names.fullname" . }}-execution
-  {{- if .Values.execution.metrics.prometheusRule.namespace }}
-  namespace: {{ .Values.execution.metrics.prometheusRule.namespace }}
+  {{- if .Values.global.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.global.metrics.prometheusRule.namespace }}
   {{- else }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.execution.metrics.prometheusRule.additionalLabels }}
-    {{- toYaml .Values.execution.metrics.prometheusRule.additionalLabels | nindent 4 }}
+    {{- if .Values.global.metrics.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.global.metrics.prometheusRule.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
   groups:
-  {{- with .Values.execution.metrics.prometheusRule.rules }}
+  {{- with .Values.global.metrics.prometheusRule.rules }}
     - name: {{ include "common.names.fullname" $ }}
       rules: {{- tpl (toYaml .) $ | nindent 8 }}
   {{- end }}
-  {{- if .Values.execution.metrics.prometheusRule.default }}
+  {{- if .Values.global.metrics.prometheusRule.default }}
   {{- if eq .Values.execution.client "geth" }}
     - name: {{ include "common.names.fullname" $ }}-default
       rules:
@@ -50,23 +50,23 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ include "common.names.fullname" . }}-beacon
-  {{- if .Values.beacon.metrics.prometheusRule.namespace }}
-  namespace: {{ .Values.beacon.metrics.prometheusRule.namespace }}
+  {{- if .Values.global.metrics.prometheusRule.namespace }}
+  namespace: {{ .Values.global.metrics.prometheusRule.namespace }}
   {{- else }}
   namespace: {{ .Release.Namespace | quote }}
   {{- end }}
   labels:
     {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.beacon.metrics.prometheusRule.additionalLabels }}
-    {{- toYaml .Values.beacon.metrics.prometheusRule.additionalLabels | nindent 4 }}
+    {{- if .Values.global.metrics.prometheusRule.additionalLabels }}
+    {{- toYaml .Values.global.metrics.prometheusRule.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
   groups:
-  {{- with .Values.beacon.metrics.prometheusRule.rules }}
+  {{- with .Values.global.metrics.prometheusRule.rules }}
     - name: {{ include "common.names.fullname" $ }}
       rules: {{- tpl (toYaml .) $ | nindent 8 }}
   {{- end }}
-  {{- if .Values.beacon.metrics.prometheusRule.default }}
+  {{- if .Values.global.metrics.prometheusRule.default }}
   {{- if eq .Values.beacon.client "lighthouse" }}
     - name: {{ include "common.names.fullname" $ }}-default
       rules:

--- a/charts/execution-beacon/templates/prometheusrules.yaml
+++ b/charts/execution-beacon/templates/prometheusrules.yaml
@@ -148,6 +148,28 @@ spec:
           annotations:
             summary: Teku beacon node is out of sync
             description: Check {{ printf  "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
+  {{- else if  eq .Values.beacon.client "nimbus" }}
+    - name: {{ include "common.names.fullname" $ }}-default
+      rules:
+        - alert: NimbusBeaconNodeDown
+          expr: up{job='{{ include "common.names.fullname" . }}'} == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: Nimbus beacon node is down
+            description: Check {{ printf "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
+  {{- else if  eq .Values.beacon.client "lodestar" }}
+    - name: {{ include "common.names.fullname" $ }}-default
+      rules:
+        - alert: LodestarBeaconNodeDown
+          expr: up{job='{{ include "common.names.fullname" . }}'} == 0
+          for: 1m
+          labels:
+            severity: critical
+          annotations:
+            summary: Lodestar beacon node is down
+            description: Check {{ printf "{{ $labels.pod }}" }} beacon node in namespace {{ printf "{{ $labels.namespace }}" }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -722,6 +722,7 @@ spec:
         - name: ethsider
           image: "{{ .Values.global.ethsider.repository }}:{{ .Values.global.ethsider.tag }}"
           imagePullPolicy: {{ .Values.global.ethsider.pullPolicy }}
+          securityContext:
             {{- toYaml .Values.global.securityContext | nindent 12 }}
           env:
             - name: EXECUTION_ENDPOINT

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -58,6 +58,9 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: POD_IP
               valueFrom:
@@ -102,6 +105,9 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           command:
             - sh
             - -ac
@@ -133,6 +139,9 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           {{- if .Values.global.externalSecrets.enabled }}
           envFrom:
             - secretRef:
@@ -395,6 +404,9 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           {{/*
           Configuration for Prysm beacon client
           */}}

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -37,10 +37,8 @@ spec:
       nodeSelector:
         {{ toYaml . | nindent 8 | trim }}
     {{- end }}
-    {{- with .Values.global.securityContext }}
       securityContext:
-        {{ toYaml . | nindent 8 | trim }}
-    {{- end }}
+        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
     {{- if .Values.global.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ .Values.global.terminationGracePeriodSeconds }}
     {{- end }}
@@ -54,13 +52,7 @@ spec:
           image: "{{ .Values.global.initImage.repository }}:{{ .Values.global.initImage.tag }}"
           imagePullPolicy: {{ .Values.global.initImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           env:
             - name: POD_IP
               valueFrom:
@@ -101,13 +93,7 @@ spec:
           image: "{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).repository }}:{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).tag }}"
           imagePullPolicy: {{ .Values.beacon.imagePullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           command:
             - sh
             - -ac
@@ -135,13 +121,7 @@ spec:
           image: "{{ (pluck .Values.execution.client .Values.global.image.execution | first ).repository }}:{{ (pluck .Values.execution.client .Values.global.image.execution | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           {{- if .Values.global.externalSecrets.enabled }}
           envFrom:
             - secretRef:
@@ -400,13 +380,7 @@ spec:
           image: "{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).repository }}:{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           {{/*
           Configuration for Prysm beacon client
           */}}
@@ -748,14 +722,7 @@ spec:
         - name: ethsider
           image: "{{ .Values.global.ethsider.repository }}:{{ .Values.global.ethsider.tag }}"
           imagePullPolicy: {{ .Values.global.ethsider.pullPolicy }}
-          securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           env:
             - name: EXECUTION_ENDPOINT
               value: "http://localhost:{{ .Values.execution.jsonrpc.http.port }}"

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -121,7 +121,12 @@ spec:
           image: "{{ (pluck .Values.execution.client .Values.global.image.execution | first ).repository }}:{{ (pluck .Values.execution.client .Values.global.image.execution | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 10000
+            capabilities:
+              drop:
+              - ALL
           {{- if .Values.global.externalSecrets.enabled }}
           envFrom:
             - secretRef:

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -54,10 +54,10 @@ spec:
           image: "{{ .Values.global.initImage.repository }}:{{ .Values.global.initImage.tag }}"
           imagePullPolicy: {{ .Values.global.initImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
           env:
             - name: POD_IP
               valueFrom:
@@ -98,10 +98,10 @@ spec:
           image: "{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).repository }}:{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).tag }}"
           imagePullPolicy: {{ .Values.beacon.imagePullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
           command:
             - sh
             - -ac
@@ -129,10 +129,10 @@ spec:
           image: "{{ (pluck .Values.execution.client .Values.global.image.execution | first ).repository }}:{{ (pluck .Values.execution.client .Values.global.image.execution | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
           command:
             - sh
             - -ac
@@ -394,10 +394,10 @@ spec:
           image: "{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).repository }}:{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
           {{/*
           Configuration for Prysm beacon client
           */}}

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -748,6 +748,14 @@ spec:
         - name: ethsider
           image: "{{ .Values.global.ethsider.repository }}:{{ .Values.global.ethsider.tag }}"
           imagePullPolicy: {{ .Values.global.ethsider.pullPolicy }}
+          securityContext:
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           env:
             - name: EXECUTION_ENDPOINT
               value: "http://localhost:{{ .Values.execution.jsonrpc.http.port }}"

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -45,9 +45,7 @@ spec:
       serviceAccountName: {{ include "common.names.fullname" . }}
       priorityClassName: {{ .Values.global.priorityClassName | quote }}
       initContainers:
-        {{/*
-        Container used for initialising data directory and setting right values for ports and external_ip
-        */}}
+        {{/* Container used for initialising data directory and setting right values for ports and external_ip */}}
         - name: init
           image: "{{ .Values.global.initImage.repository }}:{{ .Values.global.initImage.tag }}"
           imagePullPolicy: {{ .Values.global.initImage.pullPolicy }}
@@ -85,9 +83,7 @@ spec:
               mountPath: /env
             - name: scripts-init
               mountPath: /scripts
-        {{/*
-        Container used for initialising nimbus checkpoint sync
-        */}}
+        {{/* Container used for initialising nimbus checkpoint sync */}}
         {{- if and (eq .Values.beacon.client "nimbus") .Values.beacon.checkPointSync.enabled }}
         - name: init-nimbus
           image: "{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).repository }}:{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).tag }}"
@@ -114,9 +110,7 @@ spec:
           {{- end }}
         {{- end }}
       containers:
-        {{/*
-        Container used for Execution clients: Nethermind, Geth, Besu, Erigon
-        */}}
+        {{/* Container used for Execution clients: Nethermind, Geth, Besu, Erigon */}}
         - name: execution
           image: "{{ (pluck .Values.execution.client .Values.global.image.execution | first ).repository }}:{{ (pluck .Values.execution.client .Values.global.image.execution | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
@@ -378,17 +372,18 @@ spec:
           resources:
             {{ toYaml . | nindent 12 | trim }}
           {{- end }}
-        {{/*
-        Container used for Beacon clients: Prysm, Teku, Lighthouse, Nimbus, Lodestar
-        */}}
+        {{/* Container used for Beacon clients: Prysm, Teku, Lighthouse, Nimbus, Lodestar */}}
         - name: beacon
           image: "{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).repository }}:{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
-          {{/*
-          Configuration for Prysm beacon client
-          */}}
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 10000
+            capabilities:
+              drop:
+              - ALL
+          {{/* Configuration for Prysm beacon client */}}
           {{- if eq .Values.beacon.client "prysm" }}
           args: 
             - "--datadir=/data/beacon"
@@ -440,9 +435,7 @@ spec:
           {{- range .Values.beacon.extraFlags }}
             - {{ . | quote }}
           {{- end }}
-          {{/*
-          Configuration for Teku beacon client
-          */}}
+          {{/* Configuration for Teku beacon client */}}
           {{- else if eq .Values.beacon.client "teku" }}
           command:
             - sh
@@ -499,9 +492,7 @@ spec:
             {{- range .Values.beacon.extraFlags }}
               {{ . | quote }}
             {{- end }}
-           {{/*
-          Configuration for Lighthouse beacon client
-          */}}
+           {{/* Configuration for Lighthouse beacon client */}}
           {{- else if eq .Values.beacon.client "lighthouse" }}
           command:
             - sh
@@ -556,9 +547,7 @@ spec:
             {{- range .Values.beacon.extraFlags }}
               {{ . }}
             {{- end }}
-          {{/*
-          Configuration for Nimbus beacon client
-          */}}
+          {{/* Configuration for Nimbus beacon client */}}
           {{- else if eq .Values.beacon.client "nimbus" }}
           command:
             - sh
@@ -608,9 +597,7 @@ spec:
             {{- range .Values.beacon.extraFlags }}
               {{ . }}
             {{- end }}
-          {{/*
-          Configuration for Lodestar beacon client
-          */}}
+          {{/* Configuration for Lodestar beacon client */}}
           {{- else if eq .Values.beacon.client "lodestar" }}
           command:
             - sh

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -578,7 +578,7 @@ spec:
             {{- if .Values.beacon.suggestedFeeRecipient }}
               --suggested-fee-recipient={{ .Values.beacon.suggestedFeeRecipient }}
             {{- end }}
-              --web3-url=http://localhost:{{ .Values.execution.jsonrpc.engine.port }}
+              --el=http://localhost:{{ .Values.execution.jsonrpc.engine.port }}
               --max-peers={{ .Values.beacon.targetPeers }}
               --enr-auto-update=true
             {{- if .Values.global.p2pNodePort.enabled }}

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -54,8 +54,10 @@ spec:
           image: "{{ .Values.global.initImage.repository }}:{{ .Values.global.initImage.tag }}"
           imagePullPolicy: {{ .Values.global.initImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: false
-            runAsUser: 0
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
           env:
             - name: POD_IP
               valueFrom:
@@ -95,6 +97,11 @@ spec:
         - name: init-nimbus
           image: "{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).repository }}:{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).tag }}"
           imagePullPolicy: {{ .Values.beacon.imagePullPolicy }}
+          securityContext:
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
           command:
             - sh
             - -ac
@@ -121,6 +128,11 @@ spec:
         - name: execution
           image: "{{ (pluck .Values.execution.client .Values.global.image.execution | first ).repository }}:{{ (pluck .Values.execution.client .Values.global.image.execution | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
+          securityContext:
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
           command:
             - sh
             - -ac
@@ -381,6 +393,11 @@ spec:
         - name: beacon
           image: "{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).repository }}:{{ (pluck .Values.beacon.client .Values.global.image.beacon | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
+          securityContext:
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
           {{/*
           Configuration for Prysm beacon client
           */}}

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -15,13 +15,13 @@ global:
         tag: "1.24.0"
       geth: 
         repository: "ethereum/client-go"
-        tag: "v1.13.5"
+        tag: "v1.13.8"
       bseu: 
         repository: "hyperledger/besu"
         tag: "23.10.2"
       erigon: 
         repository: "thorax/erigon"
-        tag: "v2.54.0"
+        tag: "v2.55.1"
     beacon:
       prysm: 
         repository: "gcr.io/prylabs-dev/prysm/beacon-chain"
@@ -34,10 +34,10 @@ global:
         tag: "v4.5.0"
       nimbus: 
         repository: "statusim/nimbus-eth2"
-        tag: "multiarch-v23.11.0"
+        tag: "multiarch-v24.1.0"
       lodestar: 
         repository: "chainsafe/lodestar"
-        tag: "v1.12.1"
+        tag: "v1.13.0"
 
   ## JSON Web Token (JWT) authentication is used to secure the communication
   ## between the beacon node and execution client. You can generate a JWT using
@@ -242,10 +242,18 @@ global:
   ## Pod Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
-  securityContext:
+  podSecurityContext:
     runAsNonRoot: true
-    fsGroup: 1001
-    runAsUser: 1001
+    runAsUser: 10000
+    fsGroup: 10000
+
+  securityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10000
+    capabilities:
+      drop:
+      - ALL
 
 execution:
   client: nethermind

--- a/charts/mev-boost/templates/deployment.yaml
+++ b/charts/mev-boost/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
         fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
         readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default false }}
+        capabilities:
+          drop:
+            - ALL
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/mev-boost/templates/deployment.yaml
+++ b/charts/mev-boost/templates/deployment.yaml
@@ -26,22 +26,20 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "common.names.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-        runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-        fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default false }}
+        runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+        runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+        fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+        readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
         capabilities:
           drop:
             - ALL
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default false }}
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
             capabilities:
               drop:
                 - ALL

--- a/charts/mev-boost/templates/deployment.yaml
+++ b/charts/mev-boost/templates/deployment.yaml
@@ -26,23 +26,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "common.names.serviceAccountName" . }}
       securityContext:
-        runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-        runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-        fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-        readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-        capabilities:
-          drop:
-            - ALL
+        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/mev-boost/templates/deployment.yaml
+++ b/charts/mev-boost/templates/deployment.yaml
@@ -39,6 +39,9 @@ spec:
             runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default false }}
+            capabilities:
+              drop:
+                - ALL
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/mev-boost/templates/deployment.yaml
+++ b/charts/mev-boost/templates/deployment.yaml
@@ -27,10 +27,18 @@ spec:
       serviceAccountName: {{ include "common.names.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+        runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+        fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default false }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default false }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/mev-boost/values.yaml
+++ b/charts/mev-boost/values.yaml
@@ -13,7 +13,22 @@ global:
 
   serviceAccount:
     create: true
+  ## Pod Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    fsGroup: 10000
 
+  securityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10000
+    capabilities:
+      drop:
+      - ALL
+      
 # Relay URLs
 relays:
   mainnet: 
@@ -53,17 +68,6 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
-
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/charts/validators/templates/_helpers.tpl
+++ b/charts/validators/templates/_helpers.tpl
@@ -128,7 +128,7 @@ Validator graffiti
 {{- end }}
 
 {{- define "web3signer" -}}
-{{- if $.Values.web3signerEndpoint }}{{ $.Values.web3signerEndpoint }}{{- else }}http://{{ $.Values.global.project }}-web3signer-{{ $.Values.global.owner }}-web3signer:6174
+{{- if $.Values.web3signerEndpoint }}{{ $.Values.web3signerEndpoint }}{{- else }}http://{{ $.Values.global.project }}-{{ $.Values.global.label }}-web3signer:6174
 {{- end }}
 {{- end }}
 

--- a/charts/validators/templates/external-secret.yaml
+++ b/charts/validators/templates/external-secret.yaml
@@ -17,7 +17,7 @@ spec:
   {{- if empty .Values.externalSecrets.data }}
     - secretKey: ESO_DB_KEYSTORE_URL
       remoteRef:
-        key: {{ .Values.global.owner }}-external-secrets
+        key: staking-{{ .Values.global.label }}-external-secrets
         property: dbKeystoreUrl
   {{- else }}
   {{- range .Values.externalSecrets.data }}

--- a/charts/validators/templates/serviceaccount.yaml
+++ b/charts/validators/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if or .Values.global.serviceAccount.create .Values.serviceAccount.create -}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/validators/templates/serviceaccount.yaml
+++ b/charts/validators/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.global.serviceAccount.create .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create -}}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/validators/templates/statefulset.yaml
+++ b/charts/validators/templates/statefulset.yaml
@@ -122,10 +122,11 @@ spec:
               cat /data/proposerConfig.json;
               cat /data/proposerConfig.yaml;
               formatted_content=$(cat /data/signer_keys.yml | grep -o '".*"' | sed -e 's/"//g' | tr ',' '\n');
+              echo $formatted_content;
+              cat /data/signer_keys.yml;
               echo "$formatted_content" > /data/pubkeys.txt;
               echo '{"externalSigner.pubkeys": ['"$(awk '{printf "%s\"%s\"", (NR==1 ? "" : ", "), $0}' pubkeys.txt)"']}' > /data/rcconfig.json;
-              cat /data/pubkeys.txt;
-              chown -R {{ $root.Values.global.podSecurityContext.runAsUser }}:{{ $root.Values.global.podSecurityContext.runAsUser }} /data;
+              cat /data/rcconfig.json;
            {{- if eq $root.Values.type "nimbus" }}	
               find /data/nimbus -type d -name '0x*' -exec chmod 0600 {}/remote_keystore.json \;	
             {{- end }}

--- a/charts/validators/templates/statefulset.yaml
+++ b/charts/validators/templates/statefulset.yaml
@@ -64,10 +64,8 @@ spec:
       nodeSelector:
         {{ toYaml . | nindent 8 | trim }}
       {{- end }}
-      {{- with $root.Values.securityContext }}
       securityContext:
-        {{ toYaml . | nindent 8 | trim }}
-      {{- end }}
+        {{- toYaml $root.Values.global.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "validators.serviceAccountName" $root }}
       priorityClassName: {{ $root.Values.priorityClassName | quote }}
       initContainers:
@@ -75,7 +73,7 @@ spec:
           image: "{{ $root.Values.cliImage.repository }}:{{ $root.Values.cliImage.tag }}"
           imagePullPolicy: {{ $root.Values.cliImage.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            {{- toYaml $root.Values.global.securityContext | nindent 12 }}
           env:
             - name: WEB3SIGNER_URL
               value: {{ include "web3signer" $root }}
@@ -111,7 +109,7 @@ spec:
           image: "{{ $root.Values.initImageBusybox.repository }}:{{ $root.Values.initImageBusybox.tag }}"
           imagePullPolicy: {{ $root.Values.initImageBusybox.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            {{- toYaml $root.Values.global.securityContext | nindent 12 }}
           command:
             - sh
             - -c
@@ -139,6 +137,8 @@ spec:
         - name: watcher
           image: "{{ $root.Values.cliImage.repository }}:{{ $root.Values.cliImage.tag }}"
           imagePullPolicy: {{ $root.Values.cliImage.pullPolicy }}
+          securityContext:
+            {{- toYaml $root.Values.global.securityContext | nindent 12 }}
           env:
             - name: WEB3SIGNER_URL
               value: {{ include "web3signer" $root }}
@@ -164,6 +164,8 @@ spec:
         - name: validator
           image: "{{ (pluck $root.Values.type $root.Values.image | first ).repository }}:{{ (pluck $root.Values.type $root.Values.image | first ).tag }}"
           imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml $root.Values.global.securityContext | nindent 12 }}
           {{- if eq $root.Values.type "lodestar" }}
           command:
             - sh

--- a/charts/validators/templates/statefulset.yaml
+++ b/charts/validators/templates/statefulset.yaml
@@ -125,7 +125,7 @@ spec:
               echo "$formatted_content" > /data/pubkeys.txt;
               echo '{"externalSigner.pubkeys": ['"$(awk '{printf "%s\"%s\"", (NR==1 ? "" : ", "), $0}' pubkeys.txt)"']}' > /data/rcconfig.json;
               cat /data/pubkeys.txt;
-              chown -R {{ $root.Values.podSecurityContext.runAsUser }}:{{ $root.Values.podSecurityContext.runAsUser }} /data;
+              chown -R {{ $root.Values.global.podSecurityContext.runAsUser }}:{{ $root.Values.global.podSecurityContext.runAsUser }} /data;
            {{- if eq $root.Values.type "nimbus" }}	
               find /data/nimbus -type d -name '0x*' -exec chmod 0600 {}/remote_keystore.json \;	
             {{- end }}

--- a/charts/validators/templates/statefulset.yaml
+++ b/charts/validators/templates/statefulset.yaml
@@ -114,7 +114,6 @@ spec:
             - sh
             - -c
             - >
-              ls -lha /data;
               mkdir -p /data/lighthouse/validators;
               cp /data/validator_definitions.yml /data/lighthouse/validators/validator_definitions.yml;
               cat /data/signer_keys.yml > /data/config;
@@ -125,6 +124,7 @@ spec:
               echo "$formatted_content" > /data/pubkeys.txt;
               echo '{"externalSigner.pubkeys": ['"$(awk '{printf "%s\"%s\"", (NR==1 ? "" : ", "), $0}' /data/pubkeys.txt)"']}' > /data/rcconfig.json;
               cat /data/rcconfig.json;
+              ls -lha /data;
            {{- if eq $root.Values.type "nimbus" }}	
               find /data/nimbus -type d -name '0x*' -exec chmod 0600 {}/remote_keystore.json \;	
             {{- end }}
@@ -164,7 +164,12 @@ spec:
           image: "{{ (pluck $root.Values.type $root.Values.image | first ).repository }}:{{ (pluck $root.Values.type $root.Values.image | first ).tag }}"
           imagePullPolicy: {{ $root.Values.image.pullPolicy }}
           securityContext:
-            {{- toYaml $root.Values.global.securityContext | nindent 12 }}
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 10000
+            capabilities:
+              drop:
+              - ALL
           {{- if eq $root.Values.type "lodestar" }}
           command:
             - sh

--- a/charts/validators/templates/statefulset.yaml
+++ b/charts/validators/templates/statefulset.yaml
@@ -122,10 +122,8 @@ spec:
               cat /data/proposerConfig.json;
               cat /data/proposerConfig.yaml;
               formatted_content=$(cat /data/signer_keys.yml | grep -o '".*"' | sed -e 's/"//g' | tr ',' '\n');
-              echo $formatted_content;
-              cat /data/signer_keys.yml;
               echo "$formatted_content" > /data/pubkeys.txt;
-              echo '{"externalSigner.pubkeys": ['"$(awk '{printf "%s\"%s\"", (NR==1 ? "" : ", "), $0}' pubkeys.txt)"']}' > /data/rcconfig.json;
+              echo '{"externalSigner.pubkeys": ['"$(awk '{printf "%s\"%s\"", (NR==1 ? "" : ", "), $0}' /data/pubkeys.txt)"']}' > /data/rcconfig.json;
               cat /data/rcconfig.json;
            {{- if eq $root.Values.type "nimbus" }}	
               find /data/nimbus -type d -name '0x*' -exec chmod 0600 {}/remote_keystore.json \;	

--- a/charts/validators/templates/statefulset.yaml
+++ b/charts/validators/templates/statefulset.yaml
@@ -125,7 +125,7 @@ spec:
               echo "$formatted_content" > /data/pubkeys.txt;
               echo '{"externalSigner.pubkeys": ['"$(awk '{printf "%s\"%s\"", (NR==1 ? "" : ", "), $0}' pubkeys.txt)"']}' > /data/rcconfig.json;
               cat /data/pubkeys.txt;
-              chown -R {{ $root.Values.securityContext.runAsUser }}:{{ $root.Values.securityContext.runAsUser }} /data;
+              chown -R {{ $root.Values.podSecurityContext.runAsUser }}:{{ $root.Values.podSecurityContext.runAsUser }} /data;
            {{- if eq $root.Values.type "nimbus" }}	
               find /data/nimbus -type d -name '0x*' -exec chmod 0600 {}/remote_keystore.json \;	
             {{- end }}

--- a/charts/validators/values.yaml
+++ b/charts/validators/values.yaml
@@ -144,7 +144,7 @@ terminationGracePeriodSeconds: 120
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
-  name: "validators"
+  name: ""
   # Annotations to add to the service account
   annotations: {}
 

--- a/charts/validators/values.yaml
+++ b/charts/validators/values.yaml
@@ -7,6 +7,21 @@ global:
   project: ""
   imagePullSecrets: []
   network: mainnet
+  ## Pod Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    fsGroup: 10000
+
+  securityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10000
+    capabilities:
+      drop:
+      - ALL
 
 ## Provide a name in place of operator for `app:` labels
 ##
@@ -15,13 +30,6 @@ nameOverride: ""
 ## Provide a name to substitute for the full names of resources
 ##
 fullnameOverride: ""
-
-## Pod Security Context
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-##
-securityContext:
-  fsGroup: 1001
-  runAsUser: 1001
 
 ## RBAC configuration.
 ## ref: https://kubernetes.io/docs/reference/access-authn-authz/rbac/

--- a/charts/vouch/templates/statefulset.yaml
+++ b/charts/vouch/templates/statefulset.yaml
@@ -70,7 +70,13 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}
@@ -94,7 +100,13 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}

--- a/charts/web3signer/templates/external-secret.yaml
+++ b/charts/web3signer/templates/external-secret.yaml
@@ -17,23 +17,23 @@ spec:
   {{- if empty .Values.externalSecrets.data }}
     - secretKey: ESO_DECRYPTION_KEY
       remoteRef:
-        key: {{ .Values.global.owner }}-external-secrets
+        key: staking-{{ .Values.global.label }}-external-secrets
         property: decryptionKey
     - secretKey: ESO_DB_KEYSTORE_URL
       remoteRef:
-        key: {{ .Values.global.owner }}-external-secrets
+        key: staking-{{ .Values.global.label }}-external-secrets
         property: dbKeystoreUrl
     - secretKey: ESO_DB_URL
       remoteRef:
-        key: {{ .Values.global.owner }}-external-secrets
+        key: staking-{{ .Values.global.label }}-external-secrets
         property: dbUrl
     - secretKey: ESO_DB_USERNAME
       remoteRef:
-        key: {{ .Values.global.owner }}-external-secrets
+        key: staking-{{ .Values.global.label }}-external-secrets
         property: dbUsername
     - secretKey: ESO_DB_PASSWORD
       remoteRef:
-        key: {{ .Values.global.owner }}-external-secrets
+        key: staking-{{ .Values.global.label }}-external-secrets
         property: dbPassword
   {{- else }}
   {{- range .Values.externalSecrets.data }}

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -37,25 +37,13 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "web3signer.serviceAccountName" . }}
       securityContext:
-        runAsNonRoot: {{ .Values.global.podSecurityContext.runAsNonRoot | default true }}
-        runAsUser: {{ .Values.global.podSecurityContext.runAsUser | default 10000 }}
-        fsGroup: {{ .Values.global.podSecurityContext.fsGroup | default 10000 }}
-        readOnlyRootFilesystem: {{ .Values.global.podSecurityContext.readOnlyRootFilesystem | default true }}
-        capabilities:
-          drop:
-            - ALL
+        {{- toYaml .Values.global.podSecurityContext | nindent 8 }}
       initContainers:
         - name: init
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           command:
             - sh
             - -ac
@@ -72,13 +60,7 @@ spec:
           image: "{{ .Values.flywayImage.repository }}:{{ .Values.flywayImage.tag }}"
           imagePullPolicy: {{ .Values.flywayImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           args:
             - -user=$(ESO_DB_USERNAME)
             - -password=$(ESO_DB_PASSWORD)
@@ -94,13 +76,7 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}
@@ -111,13 +87,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -171,13 +141,7 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
+            {{- toYaml .Values.global.securityContext | nindent 12 }}
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -37,10 +37,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "web3signer.serviceAccountName" . }}
       securityContext:
-        runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
-        runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
-        fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
-        readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+        runAsNonRoot: {{ .Values.global.podSecurityContext.runAsNonRoot | default true }}
+        runAsUser: {{ .Values.global.podSecurityContext.runAsUser | default 10000 }}
+        fsGroup: {{ .Values.global.podSecurityContext.fsGroup | default 10000 }}
+        readOnlyRootFilesystem: {{ .Values.global.podSecurityContext.readOnlyRootFilesystem | default true }}
         capabilities:
           drop:
             - ALL
@@ -61,7 +61,7 @@ spec:
             - -ac
             - >
               mkdir -p /data/web3signer /data/keystore;
-              chown -R {{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /data/web3signer
+              chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.fsGroup }} /data/web3signer
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -38,18 +38,24 @@ spec:
       serviceAccountName: {{ include "web3signer.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+        runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+        fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
       initContainers:
         - name: init
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
           command:
             - sh
             - -ac
             - >
               mkdir -p /data/web3signer /data/keystore;
-              chown -R {{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /data/web3signer
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}
@@ -60,7 +66,10 @@ spec:
           image: "{{ .Values.flywayImage.repository }}:{{ .Values.flywayImage.tag }}"
           imagePullPolicy: {{ .Values.flywayImage.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
           args:
             - -user=$(ESO_DB_USERNAME)
             - -password=$(ESO_DB_PASSWORD)
@@ -76,7 +85,10 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
-            runAsUser: 0
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}
@@ -88,6 +100,10 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -169,6 +169,14 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
+          securityContext:
             runAsUser: 0
             capabilities:
               drop:

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -37,11 +37,10 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "web3signer.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-        runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-        fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-        readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+        runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+        runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+        fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+        readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
         capabilities:
           drop:
             - ALL
@@ -50,10 +49,10 @@ spec:
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
           imagePullPolicy: {{ .Values.initImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
             capabilities:
               drop:
                 - ALL
@@ -62,6 +61,7 @@ spec:
             - -ac
             - >
               mkdir -p /data/web3signer /data/keystore;
+              chown -R {{ .Values.podSecurityContext.runAsUser }}:{{ .Values.podSecurityContext.fsGroup }} /data/web3signer
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}
@@ -72,10 +72,10 @@ spec:
           image: "{{ .Values.flywayImage.repository }}:{{ .Values.flywayImage.tag }}"
           imagePullPolicy: {{ .Values.flywayImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
             capabilities:
               drop:
                 - ALL
@@ -94,10 +94,13 @@ spec:
           image: "{{ .Values.cliImage.repository }}:{{ .Values.cliImage.tag }}"
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}
@@ -108,11 +111,10 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-            runAsNonRoot: {{ .Values.securityContext.runAsNonRoot | default true }}
-            runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
-            fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            runAsNonRoot: {{ .Values.global.securityContext.runAsNonRoot | default true }}
+            runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
+            fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
+            readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
             capabilities:
               drop:
                 - ALL
@@ -173,11 +175,6 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
-            capabilities:
-              drop:
-                - ALL
-          securityContext:
-            runAsUser: 0
             capabilities:
               drop:
                 - ALL

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -49,7 +49,7 @@ spec:
             - -ac
             - >
               mkdir -p /data/web3signer /data/keystore;
-              chown -R {{ .Values.global.securityContext.runAsUser | default 10000 }}:{{ .Values.global.securityContext.fsGroup | default 10000 }} /data/web3signer
+              chown -R {{ .Values.global.podSecurityContext.runAsUser }}:{{ .Values.global.podSecurityContext.fsGroup }} /data/web3signer
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -87,7 +87,12 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.global.securityContext | nindent 12 }}
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 10000
+            capabilities:
+              drop:
+              - ALL
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -61,7 +61,7 @@ spec:
             - -ac
             - >
               mkdir -p /data/web3signer /data/keystore;
-              chown -R {{ .Values.global.securityContext.runAsUser }}:{{ .Values.global.securityContext.fsGroup }} /data/web3signer
+              chown -R {{ .Values.global.securityContext.runAsUser | default 10000 }}:{{ .Values.global.securityContext.fsGroup | default 10000 }} /data/web3signer
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}

--- a/charts/web3signer/templates/statefulset.yaml
+++ b/charts/web3signer/templates/statefulset.yaml
@@ -42,6 +42,9 @@ spec:
         runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
         fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
         readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+        capabilities:
+          drop:
+            - ALL
       initContainers:
         - name: init
           image: "{{ .Values.initImage.repository }}:{{ .Values.initImage.tag }}"
@@ -51,6 +54,9 @@ spec:
             runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           command:
             - sh
             - -ac
@@ -70,6 +76,9 @@ spec:
             runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           args:
             - -user=$(ESO_DB_USERNAME)
             - -password=$(ESO_DB_PASSWORD)
@@ -104,6 +113,9 @@ spec:
             runAsUser: {{ .Values.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem | default true }}
+            capabilities:
+              drop:
+                - ALL
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
@@ -158,6 +170,9 @@ spec:
           imagePullPolicy: {{ .Values.cliImage.pullPolicy }}
           securityContext:
             runAsUser: 0
+            capabilities:
+              drop:
+                - ALL
           envFrom:
             - secretRef:
                 name: eso-{{ include "common.names.fullname" . }}

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -22,7 +22,6 @@ global:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 10000
-    fsGroup: 10000
     capabilities:
       drop:
       - ALL

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -11,14 +11,14 @@ global:
   ##
   podSecurityContext: {}
 
-  securityContext:
-    capabilities:
-      drop:
-      - ALL
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    runAsUser: 10000
-    fsGroup: 10000
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 10000
+    # fsGroup: 10000
 
 replicaCount: 3
 

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 
 global:
-  owner: ""
+  label: ""
   serviceAccount:
     create: true
 

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -6,6 +6,18 @@ global:
   label: ""
   serviceAccount:
     create: true
+  ## Pod Security Context
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  ##
+  podSecurityContext: {}
+
+  securityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+    # runAsUser: 1000
 
 replicaCount: 3
 
@@ -115,21 +127,6 @@ serviceAccount:
   name: ""
 
 podAnnotations: {}
-
-## Pod Security Context
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-##
-podSecurityContext:
-  fsGroup: 1000
-  runAsUser: 1000
-
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
 
 service:
   type: ClusterIP

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -11,13 +11,14 @@ global:
   ##
   podSecurityContext: {}
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 1000
+  securityContext:
+    capabilities:
+      drop:
+      - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10000
+    fsGroup: 10000
 
 replicaCount: 3
 

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -14,9 +14,6 @@ global:
     runAsNonRoot: true
     runAsUser: 10000
     fsGroup: 10000
-    capabilities:
-      drop:
-      - ALL
 
   securityContext:
     readOnlyRootFilesystem: true

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -10,7 +10,6 @@ global:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
   podSecurityContext:
-    readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 10000
     fsGroup: 10000

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -9,16 +9,23 @@ global:
   ## Pod Security Context
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   ##
-  podSecurityContext: {}
+  podSecurityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10000
+    fsGroup: 10000
+    capabilities:
+      drop:
+      - ALL
 
-  securityContext: {}
-    # capabilities:
-    #   drop:
-    #   - ALL
-    # readOnlyRootFilesystem: true
-    # runAsNonRoot: true
-    # runAsUser: 10000
-    # fsGroup: 10000
+  securityContext:
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 10000
+    fsGroup: 10000
+    capabilities:
+      drop:
+      - ALL
 
 replicaCount: 3
 


### PR DESCRIPTION
Also added `capabilities:drop: - ALL` to all of the following. 

## Impacts `execution-beacon`:

init: 
* removed DIR creation + chown
* /script-init is config map is root owned, but if perms 0777 should execute okay
* /data, /data-execution, /data-beacon are PVCs so they need to have the right uid:gid (10000:10000) ahead of time
* fix: `put chown back` + `runAsUser: 0`, rest can stay

init-nimbus:
* should okay if binary is happy

execution:
* might need to take off `readOnlyRootFilesystem: true` if writing outside of mounted paths
* might need to take off `runAsNonRoot`, `runAsUser` and `fsGroup` if binary makes priviledged calls

beacon:
* might need to take off `readOnlyRootFilesystem: true` if writing outside of mounted paths
* might need to take off `runAsNonRoot`, `runAsUser` and `fsGroup` if binary makes priviledged calls

## Impacts `web3signer`:

init:
`mkdir` should just work because it's an EmptyDir (memory)
* I removed the `chown` because the EmptyDir should already be owned by 10000:10000

migrations: 
This one has higher chance of breaking depending on if it needs to write to /migrations as it's a configmap and owned by root. 
* might need to take off `readOnlyRootFilesystem: true` if writing outside of mounted paths
* might need to take off `runAsNonRoot`, `runAsUser` and `fsGroup` if binary writes to /migrations

fetch-keys:
Should be okay as /data is an EmptyDir

web3signer:
/data should be okay
* might need to take off `readOnlyRootFilesystem: true` if logging is not in /data
* might need to take off `runAsNonRoot`, `runAsUser` and `fsGroup` if binary writes to /config

previously missed fetch_keys_reloader should be okay

## Impacts `mev-boost`:
mev-boost:
* set `readOnlyRootFilesystem: false` because it looks like it's writing locally and no mounted volumes
* might need to take off `runAsNonRoot`, `runAsUser` and `fsGroup` if binary makes priviledged calls

## Impacts `dirk`:
* left it off init
* should be okay for others

## Impacts `vouch`:
* left it off init
* should be okay for others
