### PR TITLE
Fix peers not set propertly on statefulset for execution-beacon

### DIFF
--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -396,7 +396,7 @@ spec:
             - "--p2p-tcp-port={{ include "beacon.p2pPort" . }}"
             - "--p2p-udp-port={{ include "beacon.p2pPort" . }}"
           {{- end }}
-            - "--p2p-max-peers={{ .Values.beacon.targetPeers }}"
+            - "--p2p-max-peers={{ .Values.beacon.targetPeersMap.prysm }}"
             - "--accept-terms-of-use"
           {{- if .Values.global.externalSecrets.enabled }}
             - "--jwt-secret=/external-secrets/JWT_SECRET"
@@ -511,7 +511,7 @@ spec:
               --datadir=/data/beacon
               --network={{ .Values.global.network }}
               --disable-upnp
-              --target-peers={{ .Values.beacon.targetPeers }}
+              --target-peers={{ .Values.beacon.targetPeersMap.lighthouse }}
             {{- if .Values.beacon.restApi.enabled }}
               --http
               --http-port={{ index .Values.beacon.restApi.portMap "lighthouse" }}
@@ -582,7 +582,7 @@ spec:
               --suggested-fee-recipient={{ .Values.beacon.suggestedFeeRecipient }}
             {{- end }}
               --web3-url=http://localhost:{{ .Values.execution.jsonrpc.engine.port }}
-              --max-peers={{ .Values.beacon.targetPeers }}
+              --max-peers={{ .Values.beacon.targetPeersMap.nimbus }}
               --enr-auto-update=true
             {{- if .Values.global.p2pNodePort.enabled }}
               --nat=extip:$EXTERNAL_IP
@@ -639,7 +639,7 @@ spec:
               --rest.cors={{ .Values.beacon.restApi.corsOrigins | join "," }} 
             {{- end }}
               --execution.urls=http://127.0.0.1:{{ .Values.execution.jsonrpc.engine.port }}
-              --targetPeers={{ .Values.beacon.targetPeers }}
+              --targetPeers={{ .Values.beacon.targetPeersMap.lodestar }}
             {{- if .Values.global.p2pNodePort.enabled }}
               --nat
               --enr.ip=$EXTERNAL_IP

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -396,7 +396,7 @@ spec:
             - "--p2p-tcp-port={{ include "beacon.p2pPort" . }}"
             - "--p2p-udp-port={{ include "beacon.p2pPort" . }}"
           {{- end }}
-            - "--p2p-max-peers={{ .Values.beacon.targetPeersMap.prysm }}"
+            - "--p2p-max-peers={{ .Values.beacon.targetPeers }}"
             - "--accept-terms-of-use"
           {{- if .Values.global.externalSecrets.enabled }}
             - "--jwt-secret=/external-secrets/JWT_SECRET"
@@ -511,7 +511,7 @@ spec:
               --datadir=/data/beacon
               --network={{ .Values.global.network }}
               --disable-upnp
-              --target-peers={{ .Values.beacon.targetPeersMap.lighthouse }}
+              --target-peers={{ .Values.beacon.targetPeers }}
             {{- if .Values.beacon.restApi.enabled }}
               --http
               --http-port={{ index .Values.beacon.restApi.portMap "lighthouse" }}
@@ -582,7 +582,7 @@ spec:
               --suggested-fee-recipient={{ .Values.beacon.suggestedFeeRecipient }}
             {{- end }}
               --web3-url=http://localhost:{{ .Values.execution.jsonrpc.engine.port }}
-              --max-peers={{ .Values.beacon.targetPeersMap.nimbus }}
+              --max-peers={{ .Values.beacon.targetPeers }}
               --enr-auto-update=true
             {{- if .Values.global.p2pNodePort.enabled }}
               --nat=extip:$EXTERNAL_IP
@@ -639,7 +639,7 @@ spec:
               --rest.cors={{ .Values.beacon.restApi.corsOrigins | join "," }} 
             {{- end }}
               --execution.urls=http://127.0.0.1:{{ .Values.execution.jsonrpc.engine.port }}
-              --targetPeers={{ .Values.beacon.targetPeersMap.lodestar }}
+              --targetPeers={{ .Values.beacon.targetPeers }}
             {{- if .Values.global.p2pNodePort.enabled }}
               --nat
               --enr.ip=$EXTERNAL_IP

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -497,12 +497,7 @@ beacon:
     port: 4000
     portName: "rpc"
 
-  targetPeersMap:
-    teku: 50
-    prysm: 50
-    lighthouse: 50
-    nimbus: 50
-    lodestar: 50
+  targetPeers: 50
 
   ## Sets the total difficulty to manual overrides the default
   ## TERMINAL_TOTAL_DIFFICULTY value. WARNING: This flag should be used only if you


### PR DESCRIPTION
## Description

`targetPeers` was not set for  beacon nodes, were set using `targetPeersMap`.

[targetPeersMap](https://github.com/NethermindEth/charts/blob/prod/charts/execution-beacon/values.yaml#L500) is set here.