### PR TITLE
Start using Nethermind chiseled image

### DIFF
--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -28,12 +28,6 @@ data:
       echo "EXTERNAL_BEACON_PORT=$EXTERNAL_BEACON_PORT" >> /env/init-nodeport;
       echo "EXTERNAL_IP=$EXTERNAL_IP"     >> /env/init-nodeport;
       cat /env/init-nodeport;
-  {{- if eq .Values.execution.client "nethermind" }}
-      echo "NETHERMIND_NETWORKCONFIG_DISCOVERYPORT=$EXTERNAL_EXECUTION_PORT" >  /env/init-nodeport;
-      echo "NETHERMIND_NETWORKCONFIG_P2PPORT=$EXTERNAL_EXECUTION_PORT" >> /env/init-nodeport;
-      echo "NETHERMIND_NETWORKCONFIG_EXTERNALIP=$EXTERNAL_IP"     >> /env/init-nodeport;
-      cat ./env/init-nodeport;
-  {{- end }}
   {{- if eq .Values.beacon.client "prysm" }}
       touch /data/beacon/config.yaml;
       echo "p2p-host-ip: $EXTERNAL_IP" > /data/beacon/config.yaml;

--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -28,6 +28,12 @@ data:
       echo "EXTERNAL_BEACON_PORT=$EXTERNAL_BEACON_PORT" >> /env/init-nodeport;
       echo "EXTERNAL_IP=$EXTERNAL_IP"     >> /env/init-nodeport;
       cat /env/init-nodeport;
+  {{- if eq .Values.execution.client "nethermind" }}
+      echo "NETHERMIND_NETWORKCONFIG_DISCOVERYPORT=$EXTERNAL_EXECUTION_PORT" >  /env/init-nodeport;
+      echo "NETHERMIND_NETWORKCONFIG_P2PPORT=$EXTERNAL_EXECUTION_PORT" >> /env/init-nodeport;
+      echo "NETHERMIND_NETWORKCONFIG_EXTERNALIP=$EXTERNAL_IP"     >> /env/init-nodeport;
+      cat ./env/init-nodeport;
+  {{- end }}
   {{- if eq .Values.beacon.client "prysm" }}
       touch /data/beacon/config.yaml;
       echo "p2p-host-ip: $EXTERNAL_IP" > /data/beacon/config.yaml;

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -371,7 +371,12 @@ spec:
               readOnly: true
             {{- end }}
             - name: env-nodeport
+          {{- if eq .Values.execution.client "nethermind" }}
+              mountPath: /.env
+              subPath: init-nodeport
+          {{- else }}
               mountPath: /env
+          {{- end }}
           {{- with .Values.execution.resources }}
           resources:
             {{ toYaml . | nindent 12 | trim }}
@@ -715,12 +720,7 @@ spec:
               readOnly: true
           {{- end }}
             - name: env-nodeport
-          {{- if eq .Values.execution.client "nethermind" }}
-              mountPath: /.env
-              subPath: init-nodeport
-          {{- else }}
               mountPath: /env
-          {{- end }}
         {{- with .Values.beacon.resources }}
           resources:
             {{ toYaml . | nindent 12 | trim }}

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -315,7 +315,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          {{- if and (eq .Values.execution.client "nethermind") (.Values.global.p2pNodePort.enabled) }} }}
+          {{- if and (eq .Values.execution.client "nethermind") (.Values.global.p2pNodePort.enabled) }}
             {{- range $i, $e := until (int .Values.global.replicaCount) }}
             {{- $portExecution := add $.Values.global.p2pNodePort.startAtExecution $i }}
             {{- if hasKey $.Values.global.p2pNodePort.replicaToNodePort ($i | toString) }}

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -121,6 +121,53 @@ spec:
         - name: execution
           image: "{{ (pluck .Values.execution.client .Values.global.image.execution | first ).repository }}:{{ (pluck .Values.execution.client .Values.global.image.execution | first ).tag }}"
           imagePullPolicy: {{ .Values.global.image.imagePullPolicy }}
+          {{/*
+          Configuration for Nethermind execution client
+          */}}
+          {{- if eq .Values.execution.client "nethermind" }}
+          args:
+            - --config={{ .Values.global.network }}
+            - --datadir=/data/execution
+          {{- if .Values.execution.jsonrpc.enabled }}
+            - --JsonRpc.Enabled={{ .Values.execution.jsonrpc.enabled }}
+            - --JsonRpc.EnabledModules={{ .Values.execution.jsonrpc.namespaces.nethermind | join "," }}
+            - --JsonRpc.Host={{ .Values.execution.jsonrpc.host }}
+            - --JsonRpc.Port={{ .Values.execution.jsonrpc.http.port }}
+          {{- if .Values.execution.healthchecks.enabled }}
+            - --HealthChecks.Enabled={{ .Values.execution.healthchecks.enabled }}
+            - --HealthChecks.Slug={{ .Values.execution.healthchecks.slug }}
+            - --HealthChecks.PollingInterval={{ .Values.execution.healthchecks.pollingInterval }}
+            - --HealthChecks.LowStorageSpaceShutdownThreshold={{ .Values.execution.healthchecks.lowStorageSpaceShutdownThreshold }}
+            - --HealthChecks.LowStorageSpaceWarningThreshold={{ .Values.execution.healthchecks.lowStorageSpaceWarningThreshold }}
+          {{- if .Values.execution.jsonrpc.websocket.enabled }}
+            - --JsonRpc.WebSocketsPort={{ .Values.execution.jsonrpc.websocket.port }}
+          {{- end }}
+          {{- end }} 
+          {{- end }}
+          {{- if or .Values.global.JWTSecret .Values.global.externalSecrets.enabled }}
+          {{- if .Values.global.externalSecrets.enabled }}
+            - --JsonRpc.JwtSecretFile=/external-secrets/JWT_SECRET
+          {{- else }}
+            - --JsonRpc.JwtSecretFile=/secret/jwtsecret
+          {{- end }}
+            - --JsonRpc.EnginePort={{ .Values.execution.jsonrpc.engine.port }}
+            - --JsonRpc.EngineHost={{ .Values.execution.jsonrpc.host }}
+            - --JsonRpc.EngineEnabledModules={{ .Values.execution.jsonrpc.namespaces.nethermind | join "," }}
+          {{- end }}
+          {{- if and .Values.global.metrics.enabled .Values.execution.metrics.enabled }}
+            - --Metrics.Enabled={{ .Values.execution.metrics.enabled }}
+            - --Metrics.ExposePort={{ .Values.execution.metrics.port }}
+            - --Metrics.NodeName=$POD_NAME
+          {{- end }}
+            - --Network.MaxActivePeers={{ .Values.execution.targetPeers }}
+          {{- if not .Values.global.p2pNodePort.enabled }}
+            - --Network.ExternalIp=$POD_IP
+            - --Network.P2PPort={{ include "execution.p2pPort" . }}
+            - --Network.DiscoveryPort={{ include "execution.p2pPort" . }}
+          {{- end }}
+          {{- if .Values.execution.terminalTotalDifficulty }}
+            - --Merge.TerminalTotalDifficulty={{ .Values.execution.terminalTotalDifficulty }}
+          {{- end }}
           command:
             - sh
             - -ac
@@ -128,57 +175,6 @@ spec:
               {{- if .Values.global.p2pNodePort.enabled }}
               . /env/init-nodeport;
               {{- end }}
-            {{/*
-            Configuration for Nethermind execution client
-            */}}
-            {{- if eq .Values.execution.client "nethermind" }}
-              exec /nethermind/Nethermind.Runner
-              --config={{ .Values.global.network }}
-              --datadir=/data/execution
-            {{- if .Values.execution.jsonrpc.enabled }}
-              --JsonRpc.Enabled={{ .Values.execution.jsonrpc.enabled }}
-              --JsonRpc.EnabledModules={{ .Values.execution.jsonrpc.namespaces.nethermind | join "," }}
-              --JsonRpc.Host={{ .Values.execution.jsonrpc.host }}
-              --JsonRpc.Port={{ .Values.execution.jsonrpc.http.port }}
-            {{- if .Values.execution.healthchecks.enabled }}
-              --HealthChecks.Enabled={{ .Values.execution.healthchecks.enabled }}
-              --HealthChecks.Slug={{ .Values.execution.healthchecks.slug }}
-              --HealthChecks.PollingInterval={{ .Values.execution.healthchecks.pollingInterval }}
-              --HealthChecks.LowStorageSpaceShutdownThreshold={{ .Values.execution.healthchecks.lowStorageSpaceShutdownThreshold }}
-              --HealthChecks.LowStorageSpaceWarningThreshold={{ .Values.execution.healthchecks.lowStorageSpaceWarningThreshold }}
-            {{- if .Values.execution.jsonrpc.websocket.enabled }}
-              --JsonRpc.WebSocketsPort={{ .Values.execution.jsonrpc.websocket.port }}
-            {{- end }}
-            {{- end }} 
-            {{- end }}
-            {{- if or .Values.global.JWTSecret .Values.global.externalSecrets.enabled }}
-            {{- if .Values.global.externalSecrets.enabled }}
-              --JsonRpc.JwtSecretFile=/external-secrets/JWT_SECRET
-            {{- else }}
-              --JsonRpc.JwtSecretFile=/secret/jwtsecret
-            {{- end }}
-              --JsonRpc.EnginePort={{ .Values.execution.jsonrpc.engine.port }}
-              --JsonRpc.EngineHost={{ .Values.execution.jsonrpc.host }}
-              --JsonRpc.EngineEnabledModules={{ .Values.execution.jsonrpc.namespaces.nethermind | join "," }}
-            {{- end }}
-            {{- if and .Values.global.metrics.enabled .Values.execution.metrics.enabled }}
-              --Metrics.Enabled={{ .Values.execution.metrics.enabled }}
-              --Metrics.ExposePort={{ .Values.execution.metrics.port }}
-              --Metrics.NodeName=$POD_NAME
-            {{- end }}
-              --Network.MaxActivePeers={{ .Values.execution.targetPeers }}
-            {{- if .Values.global.p2pNodePort.enabled }}
-              --Network.ExternalIp=$EXTERNAL_IP
-              --Network.P2PPort=$EXTERNAL_EXECUTION_PORT
-              --Network.DiscoveryPort=$EXTERNAL_EXECUTION_PORT
-            {{- else }}
-              --Network.ExternalIp=$POD_IP
-              --Network.P2PPort={{ include "execution.p2pPort" . }}
-              --Network.DiscoveryPort={{ include "execution.p2pPort" . }}
-            {{- end }}
-            {{- if .Values.execution.terminalTotalDifficulty }}
-              --Merge.TerminalTotalDifficulty={{ .Values.execution.terminalTotalDifficulty }}
-            {{- end }}
             {{/*
             Configuration for Geth execution client
             */}}
@@ -714,7 +710,12 @@ spec:
               readOnly: true
           {{- end }}
             - name: env-nodeport
+          {{- if eq .Values.execution.client "nethermind" }}
+              mountPath: /.env
+              subPath: init-nodeport
+          {{- else }}
               mountPath: /env
+          {{- end }}
         {{- with .Values.beacon.resources }}
           resources:
             {{ toYaml . | nindent 12 | trim }}

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -182,7 +182,7 @@ spec:
             {{/*
             Configuration for Geth execution client
             */}}
-            {{- else if eq .Values.execution.client "geth" }}
+            {{- if eq .Values.execution.client "geth" }}
               exec geth
               --syncmode=snap
               --datadir=/data/execution
@@ -302,10 +302,10 @@ spec:
                 --metrics.port={{ .Values.execution.metrics.port }}
             {{- end }}
             {{- end }}
+            {{- end}}
             {{- range .Values.execution.extraFlags }}
               {{ .  }}
             {{- end }}
-          {{- end}}
           env:
             - name: POD_IP
               valueFrom:

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -315,6 +315,18 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+          {{- if and (eq .Values.execution.client "nethermind") (.Values.global.p2pNodePort.enabled) }} }}
+            {{- range $i, $e := until (int .Values.global.replicaCount) }}
+            {{- $portExecution := add $.Values.global.p2pNodePort.startAtExecution $i }}
+            {{- if hasKey $.Values.global.p2pNodePort.replicaToNodePort ($i | toString) }}
+              {{- $portExecution = index $.Values.global.p2pNodePort.replicaToNodePort ($i | toString) }}
+            {{- end }}
+            - name: NETHERMIND_NETWORKCONFIG_DISCOVERYPORT
+              value: "{{ $portExecution }}"
+            {{- end }}
+            - name: NETHERMIND_NETWORKCONFIG_P2PPORT
+              value: "{{ $portExecution }}"
+          {{- end }}
           {{- if .Values.execution.javaOpts.enabled }}
             - name: BESU_OPTS
               value: {{ .Values.execution.javaOpts.maxHeapSize }}
@@ -371,12 +383,7 @@ spec:
               readOnly: true
             {{- end }}
             - name: env-nodeport
-          {{- if eq .Values.execution.client "nethermind" }}
-              mountPath: /.env
-              subPath: init-nodeport
-          {{- else }}
               mountPath: /env
-          {{- end }}
           {{- with .Values.execution.resources }}
           resources:
             {{ toYaml . | nindent 12 | trim }}

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -323,9 +323,9 @@ spec:
             {{- end }}
             - name: NETHERMIND_NETWORKCONFIG_DISCOVERYPORT
               value: "{{ $portExecution }}"
-            {{- end }}
             - name: NETHERMIND_NETWORKCONFIG_P2PPORT
               value: "{{ $portExecution }}"
+            {{- end }}
           {{- end }}
           {{- if .Values.execution.javaOpts.enabled }}
             - name: BESU_OPTS

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -168,6 +168,10 @@ spec:
           {{- if .Values.execution.terminalTotalDifficulty }}
             - --Merge.TerminalTotalDifficulty={{ .Values.execution.terminalTotalDifficulty }}
           {{- end }}
+          {{- range .Values.execution.extraFlags }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- else }}
           command:
             - sh
             - -ac
@@ -301,6 +305,7 @@ spec:
             {{- range .Values.execution.extraFlags }}
               {{ .  }}
             {{- end }}
+          {{- end}}
           env:
             - name: POD_IP
               valueFrom:


### PR DESCRIPTION
Converts Nethermind STS configuration to use `args` instead of `commands` due to removal of distro from underlying container image which will run on `chiseled` version going onwards.

Due to lack of os in the container a static alternative to how p2p ports are set has been implemented, otherwise it would not be possible anymore to source .env file and exec the binary.