### PR TITLE
Added helm chart for rpc-eth-nodes

### DIFF
--- a/charts/ethereum-node/.helmignore
+++ b/charts/ethereum-node/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ethereum-node/Chart.yaml
+++ b/charts/ethereum-node/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+description: 'This chart acts as an umbrella chart and allows to run a ethereum execution
+  and consensus layer client. It''s also able to deploy optional monitoring applications. '
+name: ethereum-node
+type: application
+version: 0.0.19

--- a/charts/ethereum-node/charts/nethermind/.helmignore
+++ b/charts/ethereum-node/charts/nethermind/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ethereum-node/charts/nethermind/Chart.yaml
+++ b/charts/ethereum-node/charts/nethermind/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+description: 'Nethermind is an Ethereum execution layer implementation created with
+  the C# .NET tech stack, running on all major platforms including ARM. '
+home: https://nethermind.io/
+icon: https://launchpad.ethereum.org/static/media/nethermind-circle.fbbf1a32.png
+maintainers:
+- email: rafael@skyle.net
+  name: skylenet
+- email: busa.barnabas@gmail.com
+  name: barnabasbusa
+name: nethermind
+sources:
+- https://github.com/NethermindEth/nethermind
+type: application
+version: 1.0.9

--- a/charts/ethereum-node/charts/nethermind/README.md
+++ b/charts/ethereum-node/charts/nethermind/README.md
@@ -1,0 +1,125 @@
+
+# nethermind
+
+![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Nethermind is an Ethereum execution layer implementation created with the C# .NET tech stack, running on all major platforms including ARM.
+
+**Homepage:** <https://nethermind.io/>
+
+## Source Code
+
+* <https://github.com/NethermindEth/nethermind>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity configuration for pods |
+| annotations | object | `{}` | Annotations for the StatefulSet |
+| authPort | int | `8551` | Engine Port (Auth Port) |
+| containerSecurityContext | object | See `values.yaml` | The security context for containers |
+| customCommand | list | `[]` | Legacy way of overwriting the default command. You may prefer to change defaultCommandTemplate instead. |
+| defaultCommandTemplate | string | See `values.yaml` | Template used for the default command |
+| extraArgs | list | `[]` | Extra args for the nethermind container |
+| extraContainers | list | `[]` | Additional containers |
+| extraEnv | list | `[]` | Additional env variables |
+| extraPorts | list | `[]` | Additional ports. Useful when using extraContainers |
+| extraVolumeMounts | list | `[]` | Additional volume mounts |
+| extraVolumes | list | `[]` | Additional volumes |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| httpPort | int | `8545` | HTTP Port |
+| image.pullPolicy | string | `"IfNotPresent"` | nethermind container pull policy |
+| image.repository | string | `"nethermind/nethermind"` | nethermind container image repository |
+| image.tag | string | `"latest"` | nethermind container image tag |
+| imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
+| ingress.annotations | object | `{}` | Annotations for Ingress |
+| ingress.enabled | bool | `false` | Ingress resource for the HTTP API |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.tls | list | `[]` | Ingress TLS |
+| initChownData.enabled | bool | `true` | Init container to set the correct permissions to access data directories |
+| initChownData.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| initChownData.image.repository | string | `"busybox"` | Container repository |
+| initChownData.image.tag | string | `"1.34.0"` | Container tag |
+| initChownData.resources | object | `{}` | Resource requests and limits |
+| initContainers | list | `[]` | Additional init containers |
+| jwt | string | `"ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a"` | JWT secret used by client as a secret. Change this value. |
+| livenessProbe | object | See `values.yaml` | Liveness probe |
+| metricsPort | int | `9545` | Metrics Port |
+| nameOverride | string | `""` | Overrides the chart's name |
+| nodeSelector | object | `{}` | Node selector for pods |
+| p2pNodePort.enabled | bool | `false` | Expose P2P port via NodePort |
+| p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
+| p2pNodePort.initContainer.image.tag | string | `"v1.21.3"` | Container tag |
+| p2pNodePort.port | int | `31000` | NodePort to be used |
+| p2pNodePort.portForwardContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| p2pNodePort.portForwardContainer.image.repository | string | `"alpine/socat"` | Container image for the port forwarder |
+| p2pNodePort.portForwardContainer.image.tag | string | `"latest"` | Container tag |
+| p2pPort | int | `30303` | P2P Port |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
+| persistence.annotations | object | `{}` | Annotations for volume claim template |
+| persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |
+| persistence.existingClaim | string | `nil` | Use an existing PVC when persistence.enabled |
+| persistence.selector | object | `{}` | Selector for volume claim template |
+| persistence.size | string | `"20Gi"` | Requested size for volume claim template |
+| persistence.storageClassName | string | `nil` | Use a specific storage class E.g 'local-path' for local storage to achieve best performance Read more (https://github.com/rancher/local-path-provisioner) |
+| podAnnotations | object | `{}` | Pod annotations |
+| podDisruptionBudget | object | `{}` | Define the PodDisruptionBudget spec If not set then a PodDisruptionBudget will not be created |
+| podLabels | object | `{}` | Pod labels |
+| podManagementPolicy | string | `"OrderedReady"` | Pod management policy |
+| priorityClassName | string | `nil` | Pod priority class |
+| rbac.clusterRules | list | See `values.yaml` | Required ClusterRole rules |
+| rbac.create | bool | `true` | Specifies whether RBAC resources are to be created |
+| rbac.rules | list | See `values.yaml` | Required ClusterRole rules |
+| readinessProbe | object | See `values.yaml` | Readiness probe |
+| replicas | int | `1` | Number of replicas |
+| resources | object | `{}` | Resource requests and limits |
+| secretEnv | object | `{}` | Additional env variables injected via a created secret |
+| securityContext | object | See `values.yaml` | The security context for pods |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor.annotations | object | `{}` | Additional ServiceMonitor annotations |
+| serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator https://github.com/coreos/prometheus-operator |
+| serviceMonitor.interval | string | `"1m"` | ServiceMonitor scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor |
+| serviceMonitor.path | string | `"/metrics"` | Path to scrape |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabelings |
+| serviceMonitor.scheme | string | `"http"` | ServiceMonitor scheme |
+| serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |
+| serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
+| terminationGracePeriodSeconds | int | `300` | How long to wait until the pod is forcefully terminated |
+| tolerations | list | `[]` | Tolerations for pods |
+| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pods |
+| updateStrategy | object | `{"type":"RollingUpdate"}` | Update stategy for the Statefulset |
+| updateStrategy.type | string | `"RollingUpdate"` | Update stategy type |
+| wsPort | int | `8545` | WS Port |
+
+# Examples
+
+## Connecting to the goerli test network
+
+```yaml
+extraArgs:
+  - --config=goerli
+  - --Network.MaxActivePeers=60
+```
+
+## Exposing the P2P service via NodePort
+
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
+Currently nethermind doesn't allow you to announce a a different discovery port, which would be a requirement to run multiple replicas within the same chart.
+
+```yaml
+replicas: 1
+
+p2pNodePort:
+  enabled: true
+  port: 31000
+```

--- a/charts/ethereum-node/charts/nethermind/README.md.gotmpl
+++ b/charts/ethereum-node/charts/nethermind/README.md.gotmpl
@@ -1,0 +1,41 @@
+
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+# Examples
+
+## Connecting to the goerli test network
+
+```yaml
+extraArgs:
+  - --config=goerli
+  - --Network.MaxActivePeers=60
+```
+
+## Exposing the P2P service via NodePort
+
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
+Currently nethermind doesn't allow you to announce a a different discovery port, which would be a requirement to run multiple replicas within the same chart.
+
+```yaml
+replicas: 1
+
+p2pNodePort:
+  enabled: true
+  port: 31000
+```

--- a/charts/ethereum-node/charts/nethermind/ci/default-values.yaml
+++ b/charts/ethereum-node/charts/nethermind/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave empty so that CT tests with default values

--- a/charts/ethereum-node/charts/nethermind/templates/_cmd.tpl
+++ b/charts/ethereum-node/charts/nethermind/templates/_cmd.tpl
@@ -1,0 +1,6 @@
+{{/*
+# Default command
+*/}}
+{{- define "nethermind.defaultCommand" -}}
+{{- tpl .Values.defaultCommandTemplate . }}
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/_helpers.tpl
+++ b/charts/ethereum-node/charts/nethermind/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "nethermind.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "nethermind.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "nethermind.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "nethermind.labels" -}}
+helm.sh/chart: {{ include "nethermind.chart" . }}
+{{ include "nethermind.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "nethermind.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "nethermind.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "nethermind.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "nethermind.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the cluster role.
+It needs to be namespace prefixed to avoid naming conflicts when using the same deployment name across namespaces.
+*/}}
+{{- define "nethermind.clusterRoleName" -}}
+{{ .Release.Namespace }}-{{ include "nethermind.fullname" . }}
+{{- end }}
+
+{{- define "nethermind.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
+{{- print .Values.p2pPort }}
+{{- end }}
+{{- end -}}
+
+{{- define "nethermind.replicas" -}}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
+{{- print 1 }}
+{{ else }}
+{{- print .Values.replicas }}
+{{- end }}
+{{- end -}}

--- a/charts/ethereum-node/charts/nethermind/templates/clusterrole.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/clusterrole.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "nethermind.clusterRoleName" . }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+rules:
+{{- toYaml .Values.rbac.clusterRules | nindent 0 }}
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/clusterrolebinding.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "nethermind.clusterRoleName" . }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "nethermind.clusterRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "nethermind.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/ingress.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "nethermind.fullname" . -}}
+{{- $svcPort := .Values.httpPort -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/poddisruptionbudget.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "nethermind.fullname" . }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "nethermind.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/role.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/role.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "nethermind.serviceAccountName" . }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+rules:
+{{- toYaml .Values.rbac.rules | nindent 0 }}
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/rolebinding.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "nethermind.serviceAccountName" . }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "nethermind.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "nethermind.serviceAccountName" . }}
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/secret.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: {{ .Values.global.main.env }}-gcp-store
+spec:
+  provider:
+    gcpsm: # gcpsm provider
+      projectID: {{ .Values.global.secretStore.gcp.projectID }}
+      auth:
+        workloadIdentity:
+          clusterLocation: {{ .Values.global.secretStore.gcp.clusterLocation }}
+          clusterName: {{ .Values.global.secretStore.gcp.clusterName }}
+          serviceAccountRef:
+            name: {{ .Values.global.secretStore.gcp.serviceAccountRef.name }}
+            namespace: {{ .Values.global.secretStore.gcp.serviceAccountRef.namespace }}

--- a/charts/ethereum-node/charts/nethermind/templates/service-headless.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/service-headless.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nethermind.fullname" . }}-headless
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+    - port: {{ include "nethermind.p2pPort" . }}
+      targetPort: p2p-tcp
+      protocol: TCP
+      name: p2p-tcp
+    - port: {{ include "nethermind.p2pPort" . }}
+      targetPort: p2p-udp
+      protocol: UDP
+      name: p2p-udp
+    - port: {{ .Values.httpPort }}
+      targetPort: http-rpc
+      protocol: TCP
+      name: http-rpc
+    {{- if ne .Values.httpPort .Values.wsPort }}  
+     - port: {{ .Values.wsPort }}
+       targetPort: ws-rpc
+       protocol: TCP
+       name: ws-rpc
+     {{- end }}
+    - port: {{ .Values.authPort }}
+      targetPort: auth-rpc
+      protocol: TCP
+      name: auth-rpc  
+    - port: {{ .Values.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  {{- if .Values.extraPorts }}
+    {{ toYaml .Values.extraPorts | nindent 4}}
+  {{- end }}
+  selector:
+    {{- include "nethermind.selectorLabels" . | nindent 4 }}

--- a/charts/ethereum-node/charts/nethermind/templates/service.p2p.nodeport.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/service.p2p.nodeport.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.p2pNodePort.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nethermind.fullname" $ }}-p2p-0
+  labels:
+    {{- include "nethermind.labels" $ | nindent 4 }}
+    pod: {{ include "nethermind.fullname" $ }}-0
+    type: p2p
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+    - name: p2p-tcp
+      port: {{ include "nethermind.p2pPort" $ }}
+      protocol: TCP
+      targetPort: p2p-tcp
+      nodePort: {{ include "nethermind.p2pPort" $ }}
+    - name: p2p-udp
+      port: {{ include "nethermind.p2pPort" $ }}
+      protocol: UDP
+      targetPort: p2p-udp
+      nodePort: {{ include "nethermind.p2pPort" $ }}
+  selector:
+    {{- include "nethermind.selectorLabels" $ | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: "{{ include "nethermind.fullname" $ }}-0"
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/service.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/service.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "nethermind.fullname" . }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ include "nethermind.p2pPort" . }}
+      targetPort: p2p-tcp
+      protocol: TCP
+      name: p2p-tcp
+    - port: {{ include "nethermind.p2pPort" . }}
+      targetPort: p2p-udp
+      protocol: UDP
+      name: p2p-udp
+    - port: {{ .Values.httpPort }}
+      targetPort: http-rpc
+      protocol: TCP
+      name: http-rpc
+    {{- if ne .Values.httpPort .Values.wsPort }}  
+     - port: {{ .Values.wsPort }}
+       targetPort: ws-rpc
+       protocol: TCP
+       name: ws-rpc
+     {{- end }}
+    - port: {{ .Values.authPort }}
+      targetPort: auth-rpc
+      protocol: TCP
+      name: auth-rpc  
+    - port: {{ .Values.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  {{- if .Values.extraPorts }}
+    {{ toYaml .Values.extraPorts | nindent 4}}
+  {{- end }}
+  selector:
+    {{- include "nethermind.selectorLabels" . | nindent 4 }}

--- a/charts/ethereum-node/charts/nethermind/templates/serviceaccount.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "nethermind.serviceAccountName" . }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/servicemonitor.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "nethermind.serviceAccountName" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+  {{ toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.serviceMonitor.interval }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: metrics
+    path: {{ .Values.serviceMonitor.path }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+    {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "nethermind.selectorLabels" . | nindent 8 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/statefulset.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/statefulset.yaml
@@ -1,0 +1,204 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "nethermind.fullname" . }}
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  replicas: {{ include "nethermind.replicas" . }}
+  selector:
+    matchLabels:
+      {{- include "nethermind.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "nethermind.fullname" . }}-headless
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nethermind.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/secrets: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      # Needs to be set to false, otherwise it will inject "NETHERMIND_PORT_*" env vars which the client uses as config args.
+      # See: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#accessing-the-service
+      enableServiceLinks: false
+      serviceAccountName: {{ include "nethermind.serviceAccountName" . }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      initContainers:
+      {{- if .Values.initContainers }}
+        {{- tpl (toYaml .Values.initContainers | nindent 8) $ }}
+      {{- end }}
+      {{- if .Values.p2pNodePort.enabled }}
+        - name: init-nodeport
+          image: "{{ .Values.p2pNodePort.initContainer.image.repository }}:{{ .Values.p2pNodePort.initContainer.image.tag }}"
+          imagePullPolicy: {{.Values.p2pNodePort.initContainer.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          command:
+            - sh
+            - -c
+            - >
+              export EXTERNAL_PORT=$(kubectl get services -l "pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+              export EXTERNAL_IP=$(kubectl get nodes "${NODE_NAME}" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}');
+              echo "EXTERNAL_PORT=$EXTERNAL_PORT" >  /env/init-nodeport;
+              echo "EXTERNAL_IP=$EXTERNAL_IP"     >> /env/init-nodeport;
+              cat /env/init-nodeport;
+          volumeMounts:
+            - name: env-nodeport
+              mountPath: /env
+      {{- end }}
+      {{- if .Values.initChownData.enabled }}
+        - name: init-chown-data
+          image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
+          imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/data"]
+          resources:
+      {{ toYaml .Values.initChownData.resources | nindent 12 }}
+          volumeMounts:
+            - name: storage
+              mountPath: "/data"
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{/* Temporary fix for https://github.com/NethermindEth/nethermind/issues/3510 */}}
+          workingDir: "/data"
+          command:
+          {{- if gt (len .Values.customCommand) 0 }}
+            {{- toYaml .Values.customCommand | nindent 12}}
+          {{- else }}
+            {{- include "nethermind.defaultCommand" . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.extraVolumeMounts }}
+              {{ toYaml .Values.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.p2pNodePort.enabled }}
+            - name: env-nodeport
+              mountPath: /env
+            {{- end }}
+            - name: storage
+              mountPath: "/data"
+            - name: jwt
+              mountPath: "/data/jwt.hex"
+              subPath: jwt.hex
+              readOnly: true
+          ports:
+            - name: p2p-tcp
+              containerPort: {{ include "nethermind.p2pPort" . }}
+              protocol: TCP
+            - name: p2p-udp
+              containerPort: {{ include "nethermind.p2pPort" . }}
+              protocol: UDP
+            - name: http-rpc
+              containerPort: {{ .Values.httpPort }}
+              protocol: TCP
+            - name: ws-rpc
+              containerPort: {{ .Values.httpPort }}
+              protocol: TCP
+            - name: auth-rpc
+              containerPort: {{ .Values.authPort }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metricsPort }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
+      {{- if .Values.extraContainers }}
+        {{ tpl (toYaml .Values.extraContainers | nindent 8) $ }}
+      {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      volumes:
+        - name: jwt
+          secret:
+            secretName: {{ .Values.global.main.network }}-jwt
+      {{- if .Values.p2pNodePort.enabled }}
+        - name: env-nodeport
+          emptyDir: {}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+        {{ toYaml .Values.extraVolumes | nindent 8}}
+      {{- end }}
+  {{- if not .Values.persistence.enabled }}
+        - name: storage
+          emptyDir: {}
+  {{- else if .Values.persistence.existingClaim }}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+  {{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: storage
+      annotations:
+        {{- toYaml .Values.persistence.annotations | nindent 8 }}
+    spec:
+      accessModes:
+        {{- toYaml .Values.persistence.accessModes | nindent 8 }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
+      persistentVolumeReclaimPolicy: Retain
+      storageClassName: {{ .Values.persistence.storageClassName }}
+      {{- if .Values.persistence.selector }}
+      selector:
+        {{- toYaml .Values.persistence.selector | nindent 8 }}
+      {{- end }}
+  {{- end }}

--- a/charts/ethereum-node/charts/nethermind/templates/tests/test-connection.yaml
+++ b/charts/ethereum-node/charts/nethermind/templates/tests/test-connection.yaml
@@ -1,0 +1,28 @@
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "nethermind.fullname" . }}-test-connection"
+  labels:
+    {{- include "nethermind.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  initContainers:
+  - name: init-wait
+    image: busybox
+    command: ['sh', '-c', 'sleep 30']
+  containers:
+    - name: curl
+      image: curlimages/curl
+      command: ['curl']
+      args:
+        - --location
+        - --request
+        - POST
+        - '{{ include "nethermind.fullname" . }}:{{ .Values.httpPort }}/'
+        - --header
+        - 'Content-Type: application/json'
+        - --data-raw
+        - '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":83}'
+  restartPolicy: Never

--- a/charts/ethereum-node/charts/nethermind/values.yaml
+++ b/charts/ethereum-node/charts/nethermind/values.yaml
@@ -1,0 +1,347 @@
+# -- Overrides the chart's name
+nameOverride: ""
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+# -- Number of replicas
+replicas: 1
+
+image:
+  # -- nethermind container image repository
+  repository: nethermind/nethermind
+  # -- nethermind container image tag
+  tag: latest
+  # -- nethermind container pull policy
+  pullPolicy: IfNotPresent
+
+# -- Extra args for the nethermind container
+extraArgs: []
+  #- --config=goerli
+
+# -- JWT secret used by client as a secret. Change this value.
+jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
+
+# -- Template used for the default command
+# @default -- See `values.yaml`
+defaultCommandTemplate: |
+  - sh
+  - -ac
+  - >
+  {{- if .Values.p2pNodePort.enabled }}
+    . /env/init-nodeport;
+  {{- end }}
+    exec /nethermind/nethermind
+    --datadir=/data
+    --KeyStore.KeyStoreDirectory=/data/keystore
+    --Network.LocalIp=$(POD_IP)
+  {{- if .Values.p2pNodePort.enabled }}
+    {{- if not (contains "--Network.ExternalIp=" (.Values.extraArgs | join ",")) }}
+    --Network.ExternalIp=$EXTERNAL_IP
+    {{- end }}
+    {{- if not (contains "--Network.P2PPort=" (.Values.extraArgs | join ",")) }}
+    --Network.P2PPort=$EXTERNAL_PORT
+    {{- end }}
+    {{- if not (contains "--Network.DiscoveryPort=" (.Values.extraArgs | join ",")) }}
+    --Network.DiscoveryPort=$EXTERNAL_PORT
+    {{- end }}
+  {{- else }}
+  {{- if not (contains "--Network.ExternalIp=" (.Values.extraArgs | join ",")) }}
+    --Network.ExternalIp=$(POD_IP)
+    {{- end }}
+    {{- if not (contains "--Network.P2PPort=" (.Values.extraArgs | join ",")) }}
+    --Network.P2PPort={{ include "nethermind.p2pPort" . }}
+    {{- end }}
+    {{- if not (contains "--Network.DiscoveryPort=" (.Values.extraArgs | join ",")) }}
+    --Network.DiscoveryPort={{ include "nethermind.p2pPort" . }}
+    {{- end }}
+  {{- end }}
+    --JsonRpc.Enabled=true
+    --JsonRpc.Host=0.0.0.0
+    --JsonRpc.Port={{ .Values.httpPort }}
+    --Init.WebSocketsEnabled=true
+    --JsonRpc.WebSocketsPort={{ .Values.wsPort }}
+    --JsonRpc.JwtSecretFile=/data/jwt.hex
+    --JsonRpc.EngineHost=0.0.0.0
+    --JsonRpc.EnginePort={{ .Values.authPort }}
+    --Metrics.Enabled=true
+    --Metrics.NodeName=$(POD_NAME)
+    --Metrics.ExposePort={{ .Values.metricsPort }}
+  {{- range .Values.extraArgs }}
+    {{ tpl . $ }}
+  {{- end }}
+
+# -- Legacy way of overwriting the default command. You may prefer to change defaultCommandTemplate instead.
+customCommand: []
+
+# When p2pNodePort is enabled, your P2P port will be exposed via service type NodePort.
+# This is useful if you want to expose and announce your node to the Internet.
+# Limitation: You can only one have one replica when exposing via NodePort.
+#             Check the chart README.md for more details
+p2pNodePort:
+  # -- Expose P2P port via NodePort
+  enabled: false
+  # -- NodePort to be used
+  port: 31000
+  initContainer:
+    image:
+      # -- Container image to fetch nodeport information
+      repository: lachlanevenson/k8s-kubectl
+      # -- Container tag
+      tag: v1.21.3
+      # -- Container pull policy
+      pullPolicy: IfNotPresent
+  portForwardContainer:
+    image:
+      # -- Container image for the port forwarder
+      repository: alpine/socat
+      # -- Container tag
+      tag: latest
+      # -- Container pull policy
+      pullPolicy: IfNotPresent
+
+ingress:
+  # -- Ingress resource for the HTTP API
+  enabled: false
+  # -- Annotations for Ingress
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # -- Ingress host
+  hosts:
+    - host: chart-example.local
+      paths: []
+  # -- Ingress TLS
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# -- Affinity configuration for pods
+affinity: {}
+
+# -- Image pull secrets for Docker images
+imagePullSecrets: []
+
+# -- Annotations for the StatefulSet
+annotations: {}
+
+# -- Liveness probe
+# @default -- See `values.yaml`
+livenessProbe:
+  tcpSocket:
+    port: http-rpc
+  initialDelaySeconds: 60
+  periodSeconds: 120
+
+# -- Readiness probe
+# @default -- See `values.yaml`
+readinessProbe:
+  tcpSocket:
+    port: http-rpc
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+# -- P2P Port
+p2pPort: 30303
+
+# -- HTTP Port
+httpPort: 8545
+
+# -- WS Port
+wsPort: 8545
+
+# -- Engine Port (Auth Port)
+authPort: 8551
+
+# -- Metrics Port
+metricsPort: 9545
+
+# -- Node selector for pods
+nodeSelector: {}
+
+persistence:
+  # -- Uses an EmptyDir when not enabled
+  enabled: false
+  # -- Use an existing PVC when persistence.enabled
+  existingClaim: null
+  # -- Access mode for the volume claim template
+  accessModes:
+  - ReadWriteOnce
+  # -- Requested size for volume claim template
+  size: 20Gi
+  # -- Use a specific storage class
+  # E.g 'local-path' for local storage to achieve best performance
+  # Read more (https://github.com/rancher/local-path-provisioner)
+  storageClassName: null
+  # -- Annotations for volume claim template
+  annotations: {}
+  # -- Selector for volume claim template
+  selector: {}
+  #   matchLabels:
+  #     app.kubernetes.io/name: something
+
+# -- Pod labels
+podLabels: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod management policy
+podManagementPolicy: OrderedReady
+
+# -- Pod priority class
+priorityClassName: null
+
+rbac:
+  # -- Specifies whether RBAC resources are to be created
+  create: true
+  # -- Required ClusterRole rules
+  # @default -- See `values.yaml`
+  clusterRules:
+     # Required to obtain the nodes external IP
+    - apiGroups: [""]
+      resources:
+      - "nodes"
+      verbs:
+      - "get"
+      - "list"
+      - "watch"
+  # -- Required ClusterRole rules
+  # @default -- See `values.yaml`
+  rules:
+    # Required to get information about the serices nodePort.
+    - apiGroups: [""]
+      resources:
+      - "services"
+      verbs:
+      - "get"
+      - "list"
+      - "watch"
+
+# -- Resource requests and limits
+resources: {}
+# limits:
+#   cpu: 500m
+#   memory: 2Gi
+# requests:
+#   cpu: 300m
+#   memory: 1Gi
+
+# -- The security context for pods
+# @default -- See `values.yaml`
+securityContext:
+  fsGroup: 10001
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+
+# -- The security context for containers
+# @default -- See `values.yaml`
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- How long to wait until the pod is forcefully terminated
+terminationGracePeriodSeconds: 300
+
+# -- Tolerations for pods
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# -- Topology Spread Constraints for pods
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+topologySpreadConstraints: []
+
+# -- Define the PodDisruptionBudget spec
+# If not set then a PodDisruptionBudget will not be created
+podDisruptionBudget: {}
+# minAvailable: 1
+# maxUnavailable: 1
+
+# -- Update stategy for the Statefulset
+updateStrategy:
+  # -- Update stategy type
+  type: RollingUpdate
+
+# -- Additional init containers
+initContainers: []
+# - name: my-init-container
+#   image: busybox:latest
+#   command: ['sh', '-c', 'echo hello']
+
+# -- Additional containers
+extraContainers: []
+
+# -- Additional volumes
+extraVolumes: []
+
+# -- Additional volume mounts
+extraVolumeMounts: []
+
+# -- Additional ports. Useful when using extraContainers
+extraPorts: []
+
+# -- Additional env variables
+extraEnv: []
+#- name: JAVA_OPTS
+#  value: "-Xmx6000m -Xms6000m"
+
+# -- Additional env variables injected via a created secret
+secretEnv: {}
+# MY_PASSWORD: supersecret
+
+initChownData:
+  # -- Init container to set the correct permissions to access data directories
+  enabled: true
+  image:
+    # -- Container repository
+    repository: busybox
+    # -- Container tag
+    tag: "1.34.0"
+    # -- Container pull policy
+    pullPolicy: IfNotPresent
+  # -- Resource requests and limits
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+
+serviceMonitor:
+  # -- If true, a ServiceMonitor CRD is created for a prometheus operator
+  # https://github.com/coreos/prometheus-operator
+  enabled: false
+  # -- Path to scrape
+  path: /metrics
+  # -- Alternative namespace for ServiceMonitor
+  namespace: null
+  # -- Additional ServiceMonitor labels
+  labels: {}
+  # -- Additional ServiceMonitor annotations
+  annotations: {}
+  # -- ServiceMonitor scrape interval
+  interval: 1m
+  # -- ServiceMonitor scheme
+  scheme: http
+  # -- ServiceMonitor TLS configuration
+  tlsConfig: {}
+  # -- ServiceMonitor scrape timeout
+  scrapeTimeout: 30s
+  # -- ServiceMonitor relabelings
+  relabelings: []

--- a/charts/ethereum-node/charts/prysm/.helmignore
+++ b/charts/ethereum-node/charts/prysm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/ethereum-node/charts/prysm/Chart.yaml
+++ b/charts/ethereum-node/charts/prysm/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+description: An open-source Ethereum 2.0 client, written in Go
+home: https://docs.prylabs.network/docs/getting-started/
+icon: https://launchpad.ethereum.org/static/media/prysmatic-labs-circle.96c803fe.png
+maintainers:
+- email: rafael@skyle.net
+  name: skylenet
+- email: busa.barnabas@gmail.com
+  name: barnabasbusa
+name: prysm
+sources:
+- https://github.com/prysmaticlabs/prysm
+type: application
+version: 1.1.1

--- a/charts/ethereum-node/charts/prysm/README.md
+++ b/charts/ethereum-node/charts/prysm/README.md
@@ -1,0 +1,239 @@
+
+# prysm
+
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+An open-source Ethereum 2.0 client, written in Go
+
+**Homepage:** <https://docs.prylabs.network/docs/getting-started/>
+
+## Source Code
+
+* <https://github.com/prysmaticlabs/prysm>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity configuration for pods |
+| annotations | object | `{}` | Annotations for the StatefulSet |
+| checkpointSync | object | `{"enabled":false,"url":""}` | Checkpoint Sync |
+| containerSecurityContext | object | See `values.yaml` | The security context for containers |
+| customCommand | list | `[]` | Legacy way of overwriting the default command. You may prefer to change defaultCommandTemplates instead. |
+| defaultBeaconCommandTemplate | string | See `values.yaml` | Template used for the default beacon command |
+| defaultValidatorCommandTemplate | string | See `values.yaml` | Template used for the default validator command |
+| extraArgs | list | `[]` | Extra args for the prysm container |
+| extraContainers | list | `[]` | Additional containers |
+| extraEnv | list | `[]` | Additional env variables |
+| extraPorts | list | `[]` | Additional ports. Useful when using extraContainers |
+| extraVolumeMounts | list | `[]` | Additional volume mounts |
+| extraVolumes | list | `[]` | Additional volumes |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| httpPort | int | `3500` | HTTP Port |
+| image.pullPolicy | string | `"IfNotPresent"` | Prysm container pull policy |
+| image.repository | string | `"ethpandaops/prysm"` | Prysm container image repository |
+| image.tag | string | `"master"` |  |
+| imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
+| ingress.annotations | object | `{}` | Annotations for Ingress |
+| ingress.enabled | bool | `false` | Ingress resource for the HTTP API |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.tls | list | `[]` | Ingress TLS |
+| initChownData.enabled | bool | `true` | Init container to set the correct permissions to access data directories |
+| initChownData.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| initChownData.image.repository | string | `"busybox"` | Container repository |
+| initChownData.image.tag | string | `"1.34.0"` | Container tag |
+| initChownData.resources | object | `{}` | Resource requests and limits |
+| initContainers | list | `[]` | Additional init containers |
+| jwt | string | `"ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a"` | JWT secret used by client as a secret. Change this value. |
+| livenessProbe | object | See `values.yaml` | Liveness probe |
+| metricsPort | int | `8080` | Metrics Port |
+| mode | string | `"beacon"` | Mode can be 'beacon' or 'validator' |
+| nameOverride | string | `""` | Overrides the chart's name |
+| nodeSelector | object | `{}` | Node selector for pods |
+| p2pNodePort.enabled | bool | `false` | Expose P2P port via NodePort |
+| p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
+| p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
+| p2pNodePort.initContainer.image.tag | string | `"v1.21.3"` | Container tag |
+| p2pNodePort.port | int | `31000` | NodePort to be used |
+| p2pPort | int | `13000` | P2P Port |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
+| persistence.annotations | object | `{}` | Annotations for volume claim template |
+| persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |
+| persistence.existingClaim | string | `nil` | Use an existing PVC when persistence.enabled |
+| persistence.selector | object | `{}` | Selector for volume claim template |
+| persistence.size | string | `"20Gi"` | Requested size for volume claim template |
+| persistence.storageClassName | string | `nil` | Use a specific storage class E.g 'local-path' for local storage to achieve best performance Read more (https://github.com/rancher/local-path-provisioner) |
+| podAnnotations | object | `{}` | Pod annotations |
+| podDisruptionBudget | object | `{}` | Define the PodDisruptionBudget spec If not set then a PodDisruptionBudget will not be created |
+| podLabels | object | `{}` | Pod labels |
+| podManagementPolicy | string | `"OrderedReady"` | Pod management policy |
+| priorityClassName | string | `nil` | Pod priority class |
+| rbac.clusterRules | list | See `values.yaml` | Required ClusterRole rules |
+| rbac.create | bool | `true` | Specifies whether RBAC resources are to be created |
+| rbac.rules | list | See `values.yaml` | Required ClusterRole rules |
+| readinessProbe | object | See `values.yaml` | Readiness probe |
+| replicas | int | `1` | Number of replicas |
+| resources | object | `{}` | Resource requests and limits |
+| rpcPort | int | `4000` | RPC Port |
+| secretEnv | object | `{}` | Additional env variables injected via a created secret |
+| securityContext | object | See `values.yaml` | The security context for pods |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor.annotations | object | `{}` | Additional ServiceMonitor annotations |
+| serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator https://github.com/coreos/prometheus-operator |
+| serviceMonitor.interval | string | `"1m"` | ServiceMonitor scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor |
+| serviceMonitor.path | string | `"/metrics"` | Path to scrape |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabelings |
+| serviceMonitor.scheme | string | `"http"` | ServiceMonitor scheme |
+| serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |
+| serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
+| terminationGracePeriodSeconds | int | `300` | How long to wait until the pod is forcefully terminated |
+| tolerations | list | `[]` | Tolerations for pods |
+| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pods |
+| updateStrategy | object | `{"type":"RollingUpdate"}` | Update stategy for the Statefulset |
+| updateStrategy.type | string | `"RollingUpdate"` | Update stategy type |
+
+# Examples
+
+## Beacon node on the Goerli testnet connected to Goerli via Infura
+
+```yaml
+mode: "beacon"
+
+extraArgs:
+  - --goerli
+  - --execution-endpoint=<EXECUTION-ENDPOINT>
+```
+
+## Exposing the P2P service via NodePort
+
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
+
+```yaml
+replicas: 1
+
+p2pNodePort:
+  enabled: true
+  port: 31000
+```
+
+## Validator node targeting a beacon node service
+
+This example runs a validator on the goerli network that targets a pre-existing `prysm-beacon`
+service by injecting the all-accounts.keystore.json` file via a secret ENV var. You could use a similar
+approach to fetch your secrets from some external secret management system (Hashicorp Vault, Azure key vault, etc.):
+
+```yaml
+replicas: 1
+
+mode: validator
+
+image:
+  repository: gcr.io/prysmaticlabs/prysm/validator
+
+initContainers:
+  - name: init-keystore
+    image: bash:latest
+    imagePullPolicy: IfNotPresent
+    command:
+    - bash
+    - -c
+    - >
+      export INDEX=$(echo $(hostname)| rev | cut -d'-' -f 1 | rev);
+      mkdir -p /data/wallet/direct/accounts/;
+      keystore="KEYSTORE_$INDEX";
+      echo ${!keystore} > /data/wallet/direct/accounts/all-accounts.keystore.json;
+      password="PASSWORD_$INDEX";
+      echo ${!password} > /data/wallet-password.txt;
+    volumeMounts:
+      - name: storage
+        mountPath: "/data"
+        readOnly:
+    env:
+      - name: PASSWORD_0
+        valueFrom:
+          secretKeyRef:
+            # Name of the secret that will be generated for you. This is normally `${RELEASE-name}-env`
+            # You might need to change this
+            name: prysm-env
+            key: PASSWORD_0
+      - name: KEYSTORE_0
+        valueFrom:
+          secretKeyRef:
+            # See comment on the previous secretKeyRef
+            name: prysm-env
+            key: KEYSTORE_0
+
+extraArgs:
+  - --wallet-dir=/data/wallet
+  - --wallet-password-file=/data/wallet-password.txt
+  - --beacon-rpc-provider=prysm-beacon:4000
+
+livenessProbe:
+  tcpSocket: null
+  exec:
+    command:
+      - /app/cmd/validator/validator
+      - accounts
+      - list
+      - --accept-terms-of-use=true
+      - --wallet-dir=/data/wallet
+      - --wallet-password-file=/data/wallet-password.txt
+  initialDelaySeconds: 60
+  periodSeconds: 120
+
+readinessProbe:
+  tcpSocket: null
+  exec:
+    command:
+      - /app/cmd/validator/validator
+      - accounts
+      - list
+      - --accept-terms-of-use=true
+      - --wallet-dir=/data/wallet
+      - --wallet-password-file=/data/wallet-password.txt
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+secretEnv:
+  # Note: Never publish any of your production secrets online. These are just used for testing purposes.
+  PASSWORD_0: NotSoSuperSecret1234!
+  KEYSTORE_0: >
+    {
+            "crypto": {
+                    "checksum": {
+                            "function": "sha256",
+                            "message": "303fd570c747d33a4ceb8b1484fd792ca023c6f0563c492215808e4b1ea138fe",
+                            "params": {}
+                    },
+                    "cipher": {
+                            "function": "aes-128-ctr",
+                            "message": "1f6589828cc7d325429753ea84bfe23ad72d64d12622c07c5121595d3f599c820ed63834b7a659650819e9aaa5a485d6736195b6aeb698861b91a3cb9d63a4864f844308e990d675fee8dc1d16f41a759372b642954e2d20de535961444f509964362ccda21f5e47a07e73c889f6288a93fe6ff315207e8aaba5f12de5e1e89351a0fa7e1c8d08252de8eef8304be5eb2eb649600f235c9e4e7cb4635d7217a7caf6af8cdedc7da4ff2c6fdf95cefeb119a1ae6376f1cf603b68028677df5e3114640b584f20f9173b348491fad52c3b7af92cd0f96fcf032f80d45b3855d0cfb90ecb3e85a3515cf5e4a9fcf849a982909ae69c249fbad1c28c0b91797ff2e555f3a3e4cc0f8e14a7c18ef8ac90bf9c6ed4b094b61bf07b7cfb7bb2a9531f24a2beeb930fd7383eb515f1f99512c1bd7fccfacce1f9b447234a36df9c89d2536281915408b18b04b1dae85565bc0a794ef4a40279afb072fa1bc012c4b668489bec8d5d4c2b29372a1bb97f299992b8eaab80648061f1094e6f790a1a007abda7c675737ac888bf360506e8378b252578bbb811c7d8dc76d76b9f845d38a3d00ee62da62113766406b78a29f9797bb24b36d5bda13063d2407b7ef3b0eb71f9a942484254611af1c2ac43622046a9aaeb04ba7d0b6a2ef2932eb7a316afb1f459d153c16dc6a7328cc362ea7312c646f1a8b86150d90da9adaf0a0eb9bdb7bb05a7ef033af81af9c015d7932603e2c57f015914454d4f1e18cc7c1185690384f8a958fe4727e01314d82588fcca268fdeefcdcc6a2c21c2fdad9db56601e02ce87a1059e980e7f266539810705a07ad4a84df8366ea04f8b5763d28cfc9c4b8ce5a9c101c75e359ef5736e843bbe0ba344c161fa9da48701a8d96b5c45edf15da99da72ab",
+                            "params": {
+                                    "iv": "964bc953dbdda657f2876c3e89cc2c90"
+                            }
+                    },
+                    "kdf": {
+                            "function": "pbkdf2",
+                            "message": "",
+                            "params": {
+                                    "c": 262144,
+                                    "dklen": 32,
+                                    "prf": "hmac-sha256",
+                                    "salt": "4c8970475c27f4aff9eb4d9c7145b39d0110c964c1979fc334def2f322fda7fd"
+                            }
+                    }
+            },
+            "uuid": "727cf6d4-41e7-46ea-98a4-da6a3b2d6a91",
+            "version": 4,
+            "name": "keystore"
+    }
+
+```

--- a/charts/ethereum-node/charts/prysm/README.md.gotmpl
+++ b/charts/ethereum-node/charts/prysm/README.md.gotmpl
@@ -1,0 +1,156 @@
+
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+# Examples
+
+## Beacon node on the Goerli testnet connected to Goerli via Infura
+
+```yaml
+mode: "beacon"
+
+extraArgs:
+  - --goerli
+  - --execution-endpoint=<EXECUTION-ENDPOINT>
+```
+
+## Exposing the P2P service via NodePort
+
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
+
+```yaml
+replicas: 1
+
+p2pNodePort:
+  enabled: true
+  port: 31000
+```
+
+## Validator node targeting a beacon node service
+
+This example runs a validator on the goerli network that targets a pre-existing `prysm-beacon`
+service by injecting the all-accounts.keystore.json` file via a secret ENV var. You could use a similar
+approach to fetch your secrets from some external secret management system (Hashicorp Vault, Azure key vault, etc.):
+
+```yaml
+replicas: 1
+
+mode: validator
+
+image:
+  repository: gcr.io/prysmaticlabs/prysm/validator
+
+initContainers:
+  - name: init-keystore
+    image: bash:latest
+    imagePullPolicy: IfNotPresent
+    command:
+    - bash
+    - -c
+    - >
+      export INDEX=$(echo $(hostname)| rev | cut -d'-' -f 1 | rev);
+      mkdir -p /data/wallet/direct/accounts/;
+      keystore="KEYSTORE_$INDEX";
+      echo ${!keystore} > /data/wallet/direct/accounts/all-accounts.keystore.json;
+      password="PASSWORD_$INDEX";
+      echo ${!password} > /data/wallet-password.txt;
+    volumeMounts:
+      - name: storage
+        mountPath: "/data"
+        readOnly:
+    env:
+      - name: PASSWORD_0
+        valueFrom:
+          secretKeyRef:
+            # Name of the secret that will be generated for you. This is normally `${RELEASE-name}-env`
+            # You might need to change this
+            name: prysm-env
+            key: PASSWORD_0
+      - name: KEYSTORE_0
+        valueFrom:
+          secretKeyRef:
+            # See comment on the previous secretKeyRef
+            name: prysm-env
+            key: KEYSTORE_0
+
+extraArgs:
+  - --wallet-dir=/data/wallet
+  - --wallet-password-file=/data/wallet-password.txt
+  - --beacon-rpc-provider=prysm-beacon:4000
+
+livenessProbe:
+  tcpSocket: null
+  exec:
+    command:
+      - /app/cmd/validator/validator
+      - accounts
+      - list
+      - --accept-terms-of-use=true
+      - --wallet-dir=/data/wallet
+      - --wallet-password-file=/data/wallet-password.txt
+  initialDelaySeconds: 60
+  periodSeconds: 120
+
+readinessProbe:
+  tcpSocket: null
+  exec:
+    command:
+      - /app/cmd/validator/validator
+      - accounts
+      - list
+      - --accept-terms-of-use=true
+      - --wallet-dir=/data/wallet
+      - --wallet-password-file=/data/wallet-password.txt
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+secretEnv:
+  # Note: Never publish any of your production secrets online. These are just used for testing purposes.
+  PASSWORD_0: NotSoSuperSecret1234!
+  KEYSTORE_0: >
+    {
+            "crypto": {
+                    "checksum": {
+                            "function": "sha256",
+                            "message": "303fd570c747d33a4ceb8b1484fd792ca023c6f0563c492215808e4b1ea138fe",
+                            "params": {}
+                    },
+                    "cipher": {
+                            "function": "aes-128-ctr",
+                            "message": "1f6589828cc7d325429753ea84bfe23ad72d64d12622c07c5121595d3f599c820ed63834b7a659650819e9aaa5a485d6736195b6aeb698861b91a3cb9d63a4864f844308e990d675fee8dc1d16f41a759372b642954e2d20de535961444f509964362ccda21f5e47a07e73c889f6288a93fe6ff315207e8aaba5f12de5e1e89351a0fa7e1c8d08252de8eef8304be5eb2eb649600f235c9e4e7cb4635d7217a7caf6af8cdedc7da4ff2c6fdf95cefeb119a1ae6376f1cf603b68028677df5e3114640b584f20f9173b348491fad52c3b7af92cd0f96fcf032f80d45b3855d0cfb90ecb3e85a3515cf5e4a9fcf849a982909ae69c249fbad1c28c0b91797ff2e555f3a3e4cc0f8e14a7c18ef8ac90bf9c6ed4b094b61bf07b7cfb7bb2a9531f24a2beeb930fd7383eb515f1f99512c1bd7fccfacce1f9b447234a36df9c89d2536281915408b18b04b1dae85565bc0a794ef4a40279afb072fa1bc012c4b668489bec8d5d4c2b29372a1bb97f299992b8eaab80648061f1094e6f790a1a007abda7c675737ac888bf360506e8378b252578bbb811c7d8dc76d76b9f845d38a3d00ee62da62113766406b78a29f9797bb24b36d5bda13063d2407b7ef3b0eb71f9a942484254611af1c2ac43622046a9aaeb04ba7d0b6a2ef2932eb7a316afb1f459d153c16dc6a7328cc362ea7312c646f1a8b86150d90da9adaf0a0eb9bdb7bb05a7ef033af81af9c015d7932603e2c57f015914454d4f1e18cc7c1185690384f8a958fe4727e01314d82588fcca268fdeefcdcc6a2c21c2fdad9db56601e02ce87a1059e980e7f266539810705a07ad4a84df8366ea04f8b5763d28cfc9c4b8ce5a9c101c75e359ef5736e843bbe0ba344c161fa9da48701a8d96b5c45edf15da99da72ab",
+                            "params": {
+                                    "iv": "964bc953dbdda657f2876c3e89cc2c90"
+                            }
+                    },
+                    "kdf": {
+                            "function": "pbkdf2",
+                            "message": "",
+                            "params": {
+                                    "c": 262144,
+                                    "dklen": 32,
+                                    "prf": "hmac-sha256",
+                                    "salt": "4c8970475c27f4aff9eb4d9c7145b39d0110c964c1979fc334def2f322fda7fd"
+                            }
+                    }
+            },
+            "uuid": "727cf6d4-41e7-46ea-98a4-da6a3b2d6a91",
+            "version": 4,
+            "name": "keystore"
+    }
+
+```

--- a/charts/ethereum-node/charts/prysm/ci/default-values.yaml
+++ b/charts/ethereum-node/charts/prysm/ci/default-values.yaml
@@ -1,0 +1,1 @@
+# Leave empty so that CT tests with default values

--- a/charts/ethereum-node/charts/prysm/ci/validator-values.yaml
+++ b/charts/ethereum-node/charts/prysm/ci/validator-values.yaml
@@ -1,0 +1,92 @@
+replicas: 1
+
+mode: validator
+
+initContainers:
+  - name: init-keystore
+    image: bash:latest
+    imagePullPolicy: IfNotPresent
+    command:
+    - bash
+    - -c
+    - >
+      export INDEX=$(echo $(hostname)| rev | cut -d'-' -f 1 | rev);
+      mkdir -p /data/wallet/direct/accounts/;
+      keystore="KEYSTORE_$INDEX";
+      echo ${!keystore} > /data/wallet/direct/accounts/all-accounts.keystore.json;
+      password="PASSWORD_$INDEX";
+      echo ${!password} > /data/wallet-password.txt;
+      echo "=================";
+      cat /data/wallet/direct/accounts/all-accounts.keystore.json;
+      echo "===============";
+      cat /data/wallet-password.txt;
+    volumeMounts:
+      - name: storage
+        mountPath: "/data"
+        readOnly:
+    env:
+      - name: PASSWORD_0
+        value: NotSoSuperSecret1234!
+      - name: KEYSTORE_0
+        value: >
+          {
+                  "crypto": {
+                          "checksum": {
+                                  "function": "sha256",
+                                  "message": "303fd570c747d33a4ceb8b1484fd792ca023c6f0563c492215808e4b1ea138fe",
+                                  "params": {}
+                          },
+                          "cipher": {
+                                  "function": "aes-128-ctr",
+                                  "message": "1f6589828cc7d325429753ea84bfe23ad72d64d12622c07c5121595d3f599c820ed63834b7a659650819e9aaa5a485d6736195b6aeb698861b91a3cb9d63a4864f844308e990d675fee8dc1d16f41a759372b642954e2d20de535961444f509964362ccda21f5e47a07e73c889f6288a93fe6ff315207e8aaba5f12de5e1e89351a0fa7e1c8d08252de8eef8304be5eb2eb649600f235c9e4e7cb4635d7217a7caf6af8cdedc7da4ff2c6fdf95cefeb119a1ae6376f1cf603b68028677df5e3114640b584f20f9173b348491fad52c3b7af92cd0f96fcf032f80d45b3855d0cfb90ecb3e85a3515cf5e4a9fcf849a982909ae69c249fbad1c28c0b91797ff2e555f3a3e4cc0f8e14a7c18ef8ac90bf9c6ed4b094b61bf07b7cfb7bb2a9531f24a2beeb930fd7383eb515f1f99512c1bd7fccfacce1f9b447234a36df9c89d2536281915408b18b04b1dae85565bc0a794ef4a40279afb072fa1bc012c4b668489bec8d5d4c2b29372a1bb97f299992b8eaab80648061f1094e6f790a1a007abda7c675737ac888bf360506e8378b252578bbb811c7d8dc76d76b9f845d38a3d00ee62da62113766406b78a29f9797bb24b36d5bda13063d2407b7ef3b0eb71f9a942484254611af1c2ac43622046a9aaeb04ba7d0b6a2ef2932eb7a316afb1f459d153c16dc6a7328cc362ea7312c646f1a8b86150d90da9adaf0a0eb9bdb7bb05a7ef033af81af9c015d7932603e2c57f015914454d4f1e18cc7c1185690384f8a958fe4727e01314d82588fcca268fdeefcdcc6a2c21c2fdad9db56601e02ce87a1059e980e7f266539810705a07ad4a84df8366ea04f8b5763d28cfc9c4b8ce5a9c101c75e359ef5736e843bbe0ba344c161fa9da48701a8d96b5c45edf15da99da72ab",
+                                  "params": {
+                                          "iv": "964bc953dbdda657f2876c3e89cc2c90"
+                                  }
+                          },
+                          "kdf": {
+                                  "function": "pbkdf2",
+                                  "message": "",
+                                  "params": {
+                                          "c": 262144,
+                                          "dklen": 32,
+                                          "prf": "hmac-sha256",
+                                          "salt": "4c8970475c27f4aff9eb4d9c7145b39d0110c964c1979fc334def2f322fda7fd"
+                                  }
+                          }
+                  },
+                  "uuid": "727cf6d4-41e7-46ea-98a4-da6a3b2d6a91",
+                  "version": 4,
+                  "name": "keystore"
+          }
+
+
+extraArgs:
+  - --wallet-dir=/data/wallet
+  - --wallet-password-file=/data/wallet-password.txt
+  - --beacon-rpc-provider=prysm-beacon:4000
+
+livenessProbe:
+  tcpSocket: null
+  exec:
+    command:
+      - /app/cmd/validator/validator
+      - accounts
+      - list
+      - --accept-terms-of-use=true
+      - --wallet-dir=/data/wallet
+      - --wallet-password-file=/data/wallet-password.txt
+  initialDelaySeconds: 60
+  periodSeconds: 120
+
+readinessProbe:
+  tcpSocket: null
+  exec:
+    command:
+      - /app/cmd/validator/validator
+      - accounts
+      - list
+      - --accept-terms-of-use=true
+      - --wallet-dir=/data/wallet
+      - --wallet-password-file=/data/wallet-password.txt
+  initialDelaySeconds: 5
+  periodSeconds: 10

--- a/charts/ethereum-node/charts/prysm/templates/_cmd.tpl
+++ b/charts/ethereum-node/charts/prysm/templates/_cmd.tpl
@@ -1,0 +1,14 @@
+{{/*
+# Beacon command
+*/}}
+{{- define "prysm.beaconCommand" -}}
+{{- tpl .Values.defaultBeaconCommandTemplate . }}
+{{- end }}
+
+
+{{/*
+# Validator command
+*/}}
+{{- define "prysm.validatorCommand" -}}
+{{- tpl .Values.defaultValidatorCommandTemplate . }}
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/_helpers.tpl
+++ b/charts/ethereum-node/charts/prysm/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prysm.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prysm.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prysm.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "prysm.labels" -}}
+helm.sh/chart: {{ include "prysm.chart" . }}
+{{ include "prysm.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "prysm.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "prysm.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prysm.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "prysm.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the cluster role.
+It needs to be namespace prefixed to avoid naming conflicts when using the same deployment name across namespaces.
+*/}}
+{{- define "prysm.clusterRoleName" -}}
+{{ .Release.Namespace }}-{{ include "prysm.fullname" . }}
+{{- end }}
+
+{{- define "prysm.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
+{{- print .Values.p2pPort }}
+{{- end }}
+{{- end -}}
+
+{{- define "prysm.replicas" -}}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
+{{- print 1 }}
+{{ else }}
+{{- print .Values.replicas }}
+{{- end }}
+{{- end -}}

--- a/charts/ethereum-node/charts/prysm/templates/clusterrole.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/clusterrole.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "prysm.clusterRoleName" . }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+rules:
+{{- toYaml .Values.rbac.clusterRules | nindent 0 }}
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/clusterrolebinding.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "prysm.clusterRoleName" . }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "prysm.clusterRoleName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "prysm.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/ingress.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "prysm.fullname" . -}}
+{{- $svcPort := .Values.httpPort -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/poddisruptionbudget.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/poddisruptionbudget.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "prysm.fullname" . }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      {{- include "prysm.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/role.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/role.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "prysm.serviceAccountName" . }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+rules:
+{{- toYaml .Values.rbac.rules | nindent 0 }}
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/rolebinding.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/rolebinding.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "prysm.serviceAccountName" . }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "prysm.serviceAccountName" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "prysm.serviceAccountName" . }}
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/secret.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.global.main.network }}-jwt
+spec:
+  refreshInterval: {{ .Values.global.secretStore.refreshInterval }}
+  secretStoreRef:
+    name: {{ .Values.global.main.env }}-gcp-store
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.global.main.network }}-jwt
+    creationPolicy: Owner
+  data:
+  - remoteRef:
+      key: {{ .Values.global.secretStore.remoteRef.key }}
+      property: {{ .Values.global.secretStore.remoteRef.property }}
+      version: "{{ .Values.global.secretStore.remoteRef.version }}"
+    secretKey: jwt.hex

--- a/charts/ethereum-node/charts/prysm/templates/service-headless.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/service-headless.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prysm.fullname" . }}-headless
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+spec:
+  clusterIP: None
+  ports:
+  {{- if eq .Values.mode "beacon" }}
+    - port: {{ include "prysm.p2pPort" . }}
+      targetPort: p2p-tcp
+      protocol: TCP
+      name: p2p-tcp
+    - port: {{ include "prysm.p2pPort" . }}
+      targetPort: p2p-udp
+      protocol: UDP
+      name: p2p-udp
+  {{- end }}
+  {{- if or (eq .Values.mode "beacon") (eq .Values.mode "validator") }}
+    - port: {{ .Values.httpPort }}
+      targetPort: http-api
+      protocol: TCP
+      name: http-api
+    - port: {{ .Values.rpcPort }}
+      targetPort: rpc
+      protocol: TCP
+      name: rpc
+    - port: {{ .Values.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  {{- end }}
+  {{- if .Values.extraPorts }}
+    {{ toYaml .Values.extraPorts | nindent 4}}
+  {{- end }}
+  selector:
+    {{- include "prysm.selectorLabels" . | nindent 4 }}

--- a/charts/ethereum-node/charts/prysm/templates/service.p2p.nodeport.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/service.p2p.nodeport.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.p2pNodePort.enabled -}}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prysm.fullname" $ }}-p2p-0
+  labels:
+    {{- include "prysm.labels" $ | nindent 4 }}
+    pod: {{ include "prysm.fullname" $ }}-0
+    type: p2p
+spec:
+  type: NodePort
+  externalTrafficPolicy: Local
+  ports:
+    - name: p2p-tcp
+      port: {{ include "prysm.p2pPort" $ }}
+      protocol: TCP
+      targetPort: p2p-tcp
+      nodePort: {{ include "prysm.p2pPort" $ }}
+    - name: p2p-udp
+      port: {{ include "prysm.p2pPort" $ }}
+      protocol: UDP
+      targetPort: p2p-udp
+      nodePort: {{ include "prysm.p2pPort" $ }}
+  selector:
+    {{- include "prysm.selectorLabels" $ | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: "{{ include "prysm.fullname" $ }}-0"
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/service.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/service.yaml
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "prysm.fullname" . }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+  {{- if eq .Values.mode "beacon" }}
+    - port: {{ include "prysm.p2pPort" . }}
+      targetPort: p2p-tcp
+      protocol: TCP
+      name: p2p-tcp
+    - port: {{ include "prysm.p2pPort" . }}
+      targetPort: p2p-udp
+      protocol: UDP
+      name: p2p-udp
+  {{- end }}
+  {{- if or (eq .Values.mode "beacon") (eq .Values.mode "validator") }}
+    - port: {{ .Values.httpPort }}
+      targetPort: http-api
+      protocol: TCP
+      name: http-api
+    - port: {{ .Values.rpcPort }}
+      targetPort: rpc
+      protocol: TCP
+      name: rpc
+    - port: {{ .Values.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  {{- end }}
+  {{- if .Values.extraPorts }}
+    {{ toYaml .Values.extraPorts | nindent 4}}
+  {{- end }}
+  selector:
+    {{- include "prysm.selectorLabels" . | nindent 4 }}

--- a/charts/ethereum-node/charts/prysm/templates/serviceaccount.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "prysm.serviceAccountName" . }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/servicemonitor.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/servicemonitor.yaml
@@ -1,0 +1,45 @@
+{{- if .Values.serviceMonitor.enabled }}
+{{- if or (eq .Values.mode "beacon") (eq .Values.mode "validator") }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "prysm.serviceAccountName" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+  {{ toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.serviceMonitor.interval }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: metrics
+    path: {{ .Values.serviceMonitor.path }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+    {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "prysm.selectorLabels" . | nindent 8 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/statefulset.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/statefulset.yaml
@@ -1,0 +1,198 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "prysm.fullname" . }}
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  podManagementPolicy: {{ .Values.podManagementPolicy }}
+  replicas: {{ include "prysm.replicas" . }}
+  selector:
+    matchLabels:
+      {{- include "prysm.selectorLabels" . | nindent 6 }}
+  serviceName: {{ include "prysm.fullname" . }}-headless
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  template:
+    metadata:
+      labels:
+        {{- include "prysm.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "prysm.serviceAccountName" . }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      initContainers:
+      {{- if .Values.initContainers }}
+        {{- tpl (toYaml .Values.initContainers | nindent 8) $ }}
+      {{- end }}
+      {{- if .Values.p2pNodePort.enabled }}
+        - name: init-nodeport
+          image: "{{ .Values.p2pNodePort.initContainer.image.repository }}:{{ .Values.p2pNodePort.initContainer.image.tag }}"
+          imagePullPolicy: {{.Values.p2pNodePort.initContainer.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          command:
+            - sh
+            - -c
+            - >
+              export EXTERNAL_PORT=$(kubectl get services -l "pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
+              export EXTERNAL_IP=$(kubectl get nodes "${NODE_NAME}" -o jsonpath='{.status.addresses[?(@.type=="ExternalIP")].address}');
+              echo "EXTERNAL_PORT=$EXTERNAL_PORT" >  /env/init-nodeport;
+              echo "EXTERNAL_IP=$EXTERNAL_IP"     >> /env/init-nodeport;
+              cat /env/init-nodeport;
+          volumeMounts:
+            - name: env-nodeport
+              mountPath: /env
+      {{- end }}
+      {{- if .Values.initChownData.enabled }}
+        - name: init-chown-data
+          image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
+          imagePullPolicy: {{ .Values.initChownData.image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          command: ["chown", "-R", "{{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }}", "/data"]
+          resources:
+      {{ toYaml .Values.initChownData.resources | nindent 12 }}
+          volumeMounts:
+            - name: storage
+              mountPath: "/data"
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          {{- if gt (len .Values.customCommand) 0 }}
+            {{- toYaml .Values.customCommand | nindent 12}}
+          {{- else if eq .Values.mode "beacon" }}
+            {{- include "prysm.beaconCommand" . | nindent 12 }}
+          {{- else if eq .Values.mode "validator" }}
+            {{- include "prysm.validatorCommand" . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.extraVolumeMounts }}
+              {{ toYaml .Values.extraVolumeMounts | nindent 12}}
+            {{- end }}
+            {{- if .Values.p2pNodePort.enabled }}
+            - name: env-nodeport
+              mountPath: /env
+            {{- end }}
+            - name: storage
+              mountPath: "/data"
+            - name: jwt
+              mountPath: "/data/jwt.hex"
+              subPath: jwt.hex
+              readOnly: true
+          ports:
+          {{- if eq .Values.mode "beacon" }}
+            - name: p2p-tcp
+              containerPort: {{ include "prysm.p2pPort" . }}
+              protocol: TCP
+            - name: p2p-udp
+              containerPort: {{ include "prysm.p2pPort" . }}
+              protocol: UDP
+          {{- end }}
+          {{- if or (eq .Values.mode "beacon") (eq .Values.mode "validator") }}
+            - name: http-api
+              containerPort: {{ .Values.httpPort }}
+              protocol: TCP
+            - name: rpc
+              containerPort: {{ .Values.rpcPort }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metricsPort }}
+          {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+            
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
+      {{- if .Values.extraContainers }}
+        {{ tpl (toYaml .Values.extraContainers | nindent 8) $ }}
+      {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      volumes:
+        - name: jwt
+          secret:
+            secretName: {{ .Values.global.main.network }}-jwt
+      {{- if .Values.p2pNodePort.enabled }}
+        - name: env-nodeport
+          emptyDir: {}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+        {{ toYaml .Values.extraVolumes | nindent 8}}
+      {{- end }}
+  {{- if not .Values.persistence.enabled }}
+        - name: storage
+          emptyDir: {}
+  {{- else if .Values.persistence.existingClaim }}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim }}
+  {{- else }}
+  volumeClaimTemplates:
+  - metadata:
+      name: storage
+      annotations:
+        {{- toYaml .Values.persistence.annotations | nindent 8 }}
+    spec:
+      accessModes:
+        {{- toYaml .Values.persistence.accessModes | nindent 8 }}
+      resources:
+        requests:
+          storage: {{ .Values.persistence.size | quote }}
+      persistentVolumeReclaimPolicy: Retain
+      storageClassName: {{ .Values.persistence.storageClassName }}
+      {{- if .Values.persistence.selector }}
+      selector:
+        {{- toYaml .Values.persistence.selector | nindent 8 }}
+      {{- end }}
+  {{- end }}

--- a/charts/ethereum-node/charts/prysm/templates/tests/test-connection.yaml
+++ b/charts/ethereum-node/charts/prysm/templates/tests/test-connection.yaml
@@ -1,0 +1,24 @@
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "prysm.fullname" . }}-test-connection"
+  labels:
+    {{- include "prysm.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  initContainers:
+  - name: init-wait
+    image: busybox
+    command: ['sh', '-c', 'sleep 30']
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+    {{- if eq .Values.mode "beacon" }}
+      args: ['{{ include "prysm.fullname" . }}:{{ .Values.httpPort }}/eth/v1/node/version']
+    {{- else }}
+      args: ['{{ include "prysm.fullname" . }}:{{ .Values.metricsPort }}/metrics']
+    {{- end }}
+  restartPolicy: Never

--- a/charts/ethereum-node/charts/prysm/values.yaml
+++ b/charts/ethereum-node/charts/prysm/values.yaml
@@ -1,0 +1,370 @@
+# -- Overrides the chart's name
+nameOverride: ""
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+# -- Number of replicas
+replicas: 1
+
+image:
+  # -- Prysm container image repository
+  #repository: gcr.io/prysmaticlabs/prysm/beacon-chain
+  repository: gcr.io/prylabs-dev/prysm/beacon-chain
+  # Note: The official beacon-chain image from prysmaticlabs doesn't contain any shell (`sh`)
+  #       which is required to detect the NodePorts when using `p2pNodePort.enabled=true`. See
+  #       the following example on how to create your own: https://github.com/skylenet/prysm-debian-docker/blob/master/Dockerfile
+  # When using a validator:
+  # repository: gcr.io/prysmaticlabs/prysm/validator
+  # -- Prysm container image tag
+  tag: v4.1.1
+  # -- Prysm container pull policy
+  pullPolicy: IfNotPresent
+
+# -- Mode can be 'beacon' or 'validator'
+mode: "beacon"
+
+# -- Extra args for the prysm container
+extraArgs: []
+  ## Example for beacon mode
+  #- --goerli
+  #- --execution-endpoint=http://your-eth1-node:8551
+  #- --checkpoint-sync-url=https://goerli.checkpoint-sync.ethdevops.io
+  #- --genesis-beacon-api-url=https://goerli.checkpoint-sync.ethdevops.io
+  #
+  ##
+  ## Example for validator mode
+  #- --goerli
+  #- --enable-doppelganger-protection
+  #- --beacon-nodes=http://prysm-beacon:5052
+
+# -- JWT secret used by client as a secret. Change this value.
+
+# -- Checkpoint Sync
+checkpointSync:
+  enabled: false
+  url: ""
+
+# -- Template used for the default beacon command
+# @default -- See `values.yaml`
+defaultBeaconCommandTemplate: |
+  - sh
+  - -ac
+  - >
+  {{- if .Values.p2pNodePort.enabled }}
+    . /env/init-nodeport;
+  {{- end }}
+    exec /app/cmd/beacon-chain/beacon-chain
+    --accept-terms-of-use=true
+    --datadir=/data
+  {{- if .Values.p2pNodePort.enabled }}
+    {{- if not (contains "--p2p-host-ip=" (.Values.extraArgs | join ",")) }}
+    --p2p-host-ip=$EXTERNAL_IP
+    {{- end }}
+    {{- if not (contains "--p2p-tcp-port=" (.Values.extraArgs | join ",")) }}
+    --p2p-tcp-port=$EXTERNAL_PORT
+    {{- end }}
+    {{- if not (contains "--p2p-udp-port" (.Values.extraArgs | join ",")) }}
+    --p2p-udp-port=$EXTERNAL_PORT
+    {{- end }}
+  {{- else }}
+    {{- if not (contains "--p2p-host-ip=" (.Values.extraArgs | join ",")) }}
+    --p2p-host-ip=$(POD_IP)
+    {{- end }}
+    {{- if not (contains "--p2p-tcp-port=" (.Values.extraArgs | join ",")) }}
+    --p2p-tcp-port={{ include "prysm.p2pPort" . }}
+    {{- end }}
+    {{- if not (contains "--p2p-udp-port=" (.Values.extraArgs | join ",")) }}
+    --p2p-udp-port={{ include "prysm.p2pPort" . }}
+    {{- end }}
+  {{- end }}
+    --rpc-host=0.0.0.0
+    --rpc-port={{ .Values.rpcPort }}
+    --jwt-secret=/data/jwt.hex
+    --grpc-gateway-host=0.0.0.0
+    --grpc-gateway-port={{ .Values.httpPort }}
+    --monitoring-host=0.0.0.0
+    --monitoring-port={{ .Values.metricsPort }}
+  {{- if .Values.checkpointSync.enabled }}
+    --checkpoint-sync-url={{ tpl .Values.checkpointSync.url $ }}
+    --genesis-beacon-api-url={{ tpl .Values.checkpointSync.url $ }}
+  {{- end }}
+  {{- range .Values.extraArgs }}
+    {{ tpl . $ }}
+  {{- end }}
+
+# -- Template used for the default validator command
+# @default -- See `values.yaml`
+defaultValidatorCommandTemplate: |
+  - sh
+  - -ac
+  - >-
+    exec /app/cmd/validator/validator
+    --accept-terms-of-use=true
+    --datadir=/data
+    --monitoring-host=0.0.0.0
+    --monitoring-port={{ .Values.metricsPort }}
+  {{- range .Values.extraArgs }}
+    {{ tpl . $ }}
+  {{- end }}
+
+# -- Legacy way of overwriting the default command. You may prefer to change defaultCommandTemplates instead.
+customCommand: []
+
+# When p2pNodePort is enabled, your P2P port will be exposed via service type NodePort.
+# This will generate a service for each replica, with a port binding via NodePort.
+# This is useful if you want to expose and announce your node to the Internet.
+p2pNodePort:
+  # -- Expose P2P port via NodePort
+  enabled: false
+  # -- NodePort to be used
+  port: 31000
+  initContainer:
+    image:
+      # -- Container image to fetch nodeport information
+      repository: lachlanevenson/k8s-kubectl
+      # -- Container tag
+      tag: v1.21.3
+      # -- Container pull policy
+      pullPolicy: IfNotPresent
+
+ingress:
+  # -- Ingress resource for the HTTP API
+  enabled: false
+  # -- Annotations for Ingress
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # -- Ingress host
+  hosts:
+    - host: chart-example.local
+      paths: []
+  # -- Ingress TLS
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# -- Affinity configuration for pods
+affinity: {}
+
+# -- Image pull secrets for Docker images
+imagePullSecrets: []
+
+# -- Annotations for the StatefulSet
+annotations: {}
+
+# -- Liveness probe
+# @default -- See `values.yaml`
+livenessProbe:
+  tcpSocket:
+    port: http-api
+  initialDelaySeconds: 60
+  periodSeconds: 120
+
+# -- Readiness probe
+# @default -- See `values.yaml`
+readinessProbe:
+  tcpSocket:
+    port: http-api
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+# -- P2P Port
+p2pPort: 13000
+
+# -- HTTP Port
+httpPort: 3500
+
+# -- Metrics Port
+metricsPort: 8080
+
+# -- RPC Port
+rpcPort: 4000
+
+# -- Node selector for pods
+nodeSelector: {}
+
+persistence:
+  # -- Uses an EmptyDir when not enabled
+  enabled: false
+  # -- Use an existing PVC when persistence.enabled
+  existingClaim: null
+  # -- Access mode for the volume claim template
+  accessModes:
+  - ReadWriteOnce
+  # -- Requested size for volume claim template
+  size: 20Gi
+  # -- Use a specific storage class
+  # E.g 'local-path' for local storage to achieve best performance
+  # Read more (https://github.com/rancher/local-path-provisioner)
+  storageClassName: null
+  # -- Annotations for volume claim template
+  annotations: {}
+  # -- Selector for volume claim template
+  selector: {}
+  #   matchLabels:
+  #     app.kubernetes.io/name: something
+
+# -- Pod labels
+podLabels: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod management policy
+podManagementPolicy: OrderedReady
+
+# -- Pod priority class
+priorityClassName: null
+
+rbac:
+  # -- Specifies whether RBAC resources are to be created
+  create: true
+  # -- Required ClusterRole rules
+  # @default -- See `values.yaml`
+  clusterRules:
+     # Required to obtain the nodes external IP
+    - apiGroups: [""]
+      resources:
+      - "nodes"
+      verbs:
+      - "get"
+      - "list"
+      - "watch"
+  # -- Required ClusterRole rules
+  # @default -- See `values.yaml`
+  rules:
+    # Required to get information about the serices nodePort.
+    - apiGroups: [""]
+      resources:
+      - "services"
+      verbs:
+      - "get"
+      - "list"
+      - "watch"
+
+# -- Resource requests and limits
+resources: {}
+# limits:
+#   cpu: 500m
+#   memory: 2Gi
+# requests:
+#   cpu: 300m
+#   memory: 1Gi
+
+# -- The security context for pods
+# @default -- See `values.yaml`
+securityContext:
+  fsGroup: 10001
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+
+# -- The security context for containers
+# @default -- See `values.yaml`
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- How long to wait until the pod is forcefully terminated
+terminationGracePeriodSeconds: 300
+
+# -- Tolerations for pods
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# -- Topology Spread Constraints for pods
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+topologySpreadConstraints: []
+
+# -- Define the PodDisruptionBudget spec
+# If not set then a PodDisruptionBudget will not be created
+podDisruptionBudget: {}
+# minAvailable: 1
+# maxUnavailable: 1
+
+# -- Update stategy for the Statefulset
+updateStrategy:
+  # -- Update stategy type
+  type: RollingUpdate
+
+# -- Additional init containers
+initContainers: []
+# - name: my-init-container
+#   image: busybox:latest
+#   command: ['sh', '-c', 'echo hello']
+
+# -- Additional containers
+extraContainers: []
+
+# -- Additional volumes
+extraVolumes: []
+
+# -- Additional volume mounts
+extraVolumeMounts: []
+
+# -- Additional ports. Useful when using extraContainers
+extraPorts: []
+
+# -- Additional env variables
+extraEnv: []
+
+# -- Additional env variables injected via a created secret
+secretEnv: {}
+# MY_PASSWORD: supersecret
+
+initChownData:
+  # -- Init container to set the correct permissions to access data directories
+  enabled: true
+  image:
+    # -- Container repository
+    repository: busybox
+    # -- Container tag
+    tag: "1.34.0"
+    # -- Container pull policy
+    pullPolicy: IfNotPresent
+  # -- Resource requests and limits
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+
+serviceMonitor:
+  # -- If true, a ServiceMonitor CRD is created for a prometheus operator
+  # https://github.com/coreos/prometheus-operator
+  enabled: false
+  # -- Path to scrape
+  path: /metrics
+  # -- Alternative namespace for ServiceMonitor
+  namespace: null
+  # -- Additional ServiceMonitor labels
+  labels: {}
+  # -- Additional ServiceMonitor annotations
+  annotations: {}
+  # -- ServiceMonitor scrape interval
+  interval: 1m
+  # -- ServiceMonitor scheme
+  scheme: http
+  # -- ServiceMonitor TLS configuration
+  tlsConfig: {}
+  # -- ServiceMonitor scrape timeout
+  scrapeTimeout: 30s
+  # -- ServiceMonitor relabelings
+  relabelings: []

--- a/charts/ethereum-node/ci/clients/consensus/prysm.yaml
+++ b/charts/ethereum-node/ci/clients/consensus/prysm.yaml
@@ -1,0 +1,2 @@
+prysm:
+  enabled: true

--- a/charts/ethereum-node/ci/clients/execution/nethermind.yaml
+++ b/charts/ethereum-node/ci/clients/execution/nethermind.yaml
@@ -1,0 +1,2 @@
+nethermind:
+  enabled: true

--- a/charts/ethereum-node/ci/networks/goerli.yaml
+++ b/charts/ethereum-node/ci/networks/goerli.yaml
@@ -1,0 +1,5 @@
+global:
+  main:
+    network: "goerli"
+  checkpointSync:
+    enabled: true

--- a/charts/ethereum-node/ci/networks/mainnet.yaml
+++ b/charts/ethereum-node/ci/networks/mainnet.yaml
@@ -1,0 +1,5 @@
+global:
+  main:
+    network: "mainnet"
+  checkpointSync:
+    enabled: true

--- a/charts/ethereum-node/ci/networks/sepolia.yaml
+++ b/charts/ethereum-node/ci/networks/sepolia.yaml
@@ -1,0 +1,5 @@
+global:
+  main:
+    network: "sepolia"
+  checkpointSync:
+    enabled: true

--- a/charts/ethereum-node/templates/NOTES.txt
+++ b/charts/ethereum-node/templates/NOTES.txt
@@ -1,0 +1,37 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+To learn more about the release, try:
+
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}
+
+====
+{{- $elName := "" -}}
+{{- $elCount := 0 | int -}}
+{{- if .Values.nethermind.enabled -}}
+{{ $elCount = add1 $elCount -}}
+{{ $elName = "nethermind" -}}
+{{- end -}}
+
+{{- $clName := "" -}}
+{{- $clCount := 0 | int -}}
+{{- if .Values.prysm.enabled -}}
+{{ $clCount = add1 $clCount -}}
+{{ $clName = "prysm" -}}
+{{- end -}}
+
+{{- if gt $elCount 1 -}}
+{{ fail "ERROR: You should only enable one execution layer client software" -}}
+{{- end -}}
+{{- if gt $clCount 1 -}}
+{{ fail "ERROR: You should only enable one consensus layer client software" -}}
+{{- end }}
+
+Infos about your ethereum node installation:
+- Network: {{ .Values.global.main.network }}
+- Execution layer client: {{ printf "%s" $elName }}
+- Consensus layer client: {{ printf "%s" $clName }}
+
+=====

--- a/charts/ethereum-node/values.yaml
+++ b/charts/ethereum-node/values.yaml
@@ -1,0 +1,160 @@
+global:
+  main:
+    network: mainnet
+    env: staging
+    engineEndpoint: http://{{ .Release.Name }}-execution:8551
+    rpcEndpoint: http://{{ .Release.Name }}-execution:8545
+    beaconEndpoint: http://{{ .Release.Name }}-beacon:5052
+  checkpointSync:
+    enabled: true
+    addresses:
+      mainnet: https://mainnet-checkpoint-sync.attestant.io
+      goerli: https://checkpoint-sync.goerli.ethpandaops.io
+      sepolia: https://checkpoint-sync.sepolia.ethpandaops.io
+  clientArgs:
+    networks:
+      mainnet:
+        execution:
+          nethermind:
+          - --Pruning.Mode=Hybrid 
+          - --Pruning.FullPruningTrigger=VolumeFreeSpace
+          - --Pruning.FullPruningThresholdMb=256000 
+          - --Pruning.AvailableSpaceCheckEnabled=false
+          - --Sync.NonValidatorNode=true
+          - --Sync.DownloadBodiesInFastSync=false
+          - --Sync.DownloadReceiptsInFastSync=false
+        consensus:
+          prysm: []
+      goerli:
+        execution:
+          nethermind:
+            - --config=goerli
+        consensus:
+          prysm:
+            - --goerli
+      sepolia:
+        execution:
+          nethermind:
+            - --config=sepolia
+        consensus:
+          prysm:
+            - --sepolia
+
+  ########################
+  ###
+  ###  Secret Store 
+  ###
+  ########################
+  secretStore:
+    gcp:
+      projectID: dummy-project-id
+      clusterLocation: dummy-cluster-location
+      clusterName: dummy-cluster-name
+      serviceAccountRef:
+        name: dummy-service-account
+        namespace: dummy-namespace
+
+    refreshInterval: "10m"
+    remoteRef:
+      version: "1"
+      key: dummy-key
+      property: dummy-property
+########################
+###
+###  Execution clients
+###
+########################
+
+nethermind:
+  enabled: true
+  nameOverride: execution
+  httpPort: 8545
+  p2pPort: 30303
+  extraArgs:
+    - >-
+      {{- with( index .Values.global.clientArgs.networks .Values.global.main.network ) }}
+        {{- range $i, $v := .execution.nethermind }}
+        {{- if (eq $i 0) }}
+        {{- $v }}
+        {{- else }}
+        {{ $v }}
+        {{- end }}
+        {{- end -}}
+      {{- end }}
+
+
+########################
+###
+###  Consensus clients
+###
+########################
+
+
+prysm:
+  enabled: true
+  nameOverride: beacon
+  httpPort: 5052
+  p2pPort: 9000
+  checkpointSync:
+    enabled: "{{ default .Values.global.checkpointSync.enabled false }}"
+    url: "{{ index .Values.global.checkpointSync.addresses .Values.global.main.network }}"
+  extraArgs:
+    - >-
+      --execution-endpoint={{ tpl .Values.global.main.engineEndpoint . }}
+      {{- with( index .Values.global.clientArgs.networks .Values.global.main.network ) }}
+        {{- range .consensus.prysm }}
+        {{ . }}
+        {{- end -}}
+      {{- end -}}
+
+  resources:
+    limits:
+      cpu: 4
+      memory: 4Gi
+    requests:
+      cpu: 2
+      memory: 2Gi
+
+  persistence:
+    # -- Uses an EmptyDir when not enabled
+    enabled: true
+    # -- Use an existing PVC when persistence.enabled
+    accessModes:
+    - ReadWriteOnce
+    # -- Requested size for volume claim template
+    size: 100Gi
+    # -- Use a specific storage class
+    # E.g 'local-path' for local storage to achieve best performance
+    # Read more (https://github.com/rancher/local-path-provisioner)
+    storageClassName: standard-rwo
+    # -- Annotations for volume claim template
+    annotations: {}
+    # -- Selector for volume claim template
+    selector: {}
+    #   matchLabels:
+    #     app.kubernetes.io/name: something
+
+
+########################
+###
+###  Monitoring
+###
+########################
+
+ethereum-metrics-exporter:
+  enabled: false
+  nameOverride: metrics-exporter
+  config:
+    consensus:
+      enabled: true
+      url: "{{ tpl  .Values.global.main.beaconEndpoint . }}"
+      name: consensus-client
+    execution:
+      enabled: true
+      url: "{{ tpl  .Values.global.main.rpcEndpoint . }}"
+      name: execution-client
+      modules:
+        - eth
+        - net
+        - web3
+


### PR DESCRIPTION
-Added Ethereum Node chart  strictly for RPC Juno
-Execution client : Nethermind
-Consensus Client: Prysm
-Network configurable: goerli , mainnet, sepolia
- Utilises External secrets for JWT token