### PR TITLE
Fix init container when p2p type is LoadBalancer

### DIFF
--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
 {{- if .Values.global.p2pNodePort.enabled }}
   {{- if eq .Values.global.p2pNodePort.type "LoadBalancer" }}
       export POD_NUMBER_SUFFIX=$(echo "${POD_NAME}" | grep -o -E '[0-9]+$')
-      export POD_PREFIX_NAME={{ include "common.names.fullname" $ }}-
+      export POD_PREFIX_NAME={{ include "common.names.fullname" $ }}
       for SERVICE_TYPE in beacon execution; do SERVICE_NAME="${POD_PREFIX_NAME}-${SERVICE_TYPE}-${POD_NUMBER_SUFFIX}"; until [ -n "$(kubectl -n ${POD_NAMESPACE} get svc/${SERVICE_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do; echo "Waiting for load balancer to get an IP for ${SERVICE_NAME}" && sleep 10; done; done;
       export EXTERNAL_EXECUTION_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
       export EXTERNAL_BEACON_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');

--- a/charts/execution-beacon/templates/configmap.yaml
+++ b/charts/execution-beacon/templates/configmap.yaml
@@ -15,10 +15,12 @@ data:
     echo "Namespace: ${POD_NAMESPACE} Pod: ${POD_NAME}";
 {{- if .Values.global.p2pNodePort.enabled }}
   {{- if eq .Values.global.p2pNodePort.type "LoadBalancer" }}
-      until [ -n "$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do echo "Waiting for load balancer to get an IP" && sleep 10; done;
+      export POD_NUMBER_SUFFIX=$(echo "${POD_NAME}" | grep -o -E '[0-9]+$')
+      export POD_PREFIX_NAME={{ include "common.names.fullname" $ }}-
+      for SERVICE_TYPE in beacon execution; do SERVICE_NAME="${POD_PREFIX_NAME}-${SERVICE_TYPE}-${POD_NUMBER_SUFFIX}"; until [ -n "$(kubectl -n ${POD_NAMESPACE} get svc/${SERVICE_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')" ]; do; echo "Waiting for load balancer to get an IP for ${SERVICE_NAME}" && sleep 10; done; done;
       export EXTERNAL_EXECUTION_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
       export EXTERNAL_BEACON_PORT=$(kubectl -n ${POD_NAMESPACE} get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
-      export EXTERNAL_IP=$(kubectl -n ${POD_NAMESPACE} get svc/${POD_NAME} -o jsonpath='{.status.loadBalancer.ingress[0].ip}');
+      export EXTERNAL_IP=$(kubectl -n ${POD_NAMESPACE} get svc/${POD_PREFIX_NAME}-beacon-${POD_NUMBER_SUFFIX} -o jsonpath='{.status.loadBalancer.ingress[0].ip}');
   {{- else }}
       export EXTERNAL_EXECUTION_PORT=$(kubectl get services -l "client=execution,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');
       export EXTERNAL_BEACON_PORT=$(kubectl get services -l "client=beacon,pod in (${POD_NAME}), type in (p2p)" -o jsonpath='{.items[0].spec.ports[0].nodePort}');


### PR DESCRIPTION
Trying to set p2p Services to LoadBalancer type and get them a proper External IP, I discovered that the init container was targeting the wrong Service names. It was using `POD_NAME` sorely instead of `<common.names.fullname>-<execution/beacon>-<replica_count_index>`. Therefore, the init container never ends.

As the External IP is only used for the beacon `config.yml`, I also adjusted the variable to get the External IP assigned to the beacon p2p service instead of the Pod's Service one (which is ClusterIP anyways and never gets an External IP address).