### PR TITLE
Fix execution extra flags generation

### DIFF
--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -160,7 +160,7 @@ spec:
             - --Merge.TerminalTotalDifficulty={{ .Values.execution.terminalTotalDifficulty }}
           {{- end }}
           {{- range .Values.execution.extraFlags }}
-            - {{ . | quote }}
+            - {{ . }}
           {{- end }}
           {{- else }}
           command:

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -284,10 +284,10 @@ spec:
               --metrics.port={{ .Values.execution.metrics.port }}
             {{- end }}
             {{- end }}
-            {{- end}}
             {{- range .Values.execution.extraFlags }}
-              {{ .  }}
+              {{ . }}
             {{- end }}
+            {{- end}}
           env:
             - name: POD_IP
               valueFrom:

--- a/charts/execution-beacon/templates/statefulset.yaml
+++ b/charts/execution-beacon/templates/statefulset.yaml
@@ -278,13 +278,10 @@ spec:
               --ws
             {{- end }}
             {{- end }}
-            {{- range .Values.extraFlags }}
-                {{ . }}
-            {{- end }}
             {{- if .Values.global.metrics.enabled }}
-                --metrics
-                --metrics.addr={{ .Values.execution.metrics.host }}
-                --metrics.port={{ .Values.execution.metrics.port }}
+              --metrics
+              --metrics.addr={{ .Values.execution.metrics.host }}
+              --metrics.port={{ .Values.execution.metrics.port }}
             {{- end }}
             {{- end }}
             {{- end}}


### PR DESCRIPTION
We have two behaviors for generating execution extra flags. One for Nethermind (each extra flag in the form of `- <extraFlag>`), and one for the rest of the clients (`<extraFlag>` as it is). When `execution.extraFlags` was set, regardless of the chosen client, the extra flags for the rest of the clients were generated, which caused a conflict with Nethermind's own extra flags generation and correctness. 

This PR fixes this issue generating non-nethermind extra flags when nethermind is not chosen.