### PR TITLE
Rolling out: `allowPrivilegeEscalation: false`

### DIFF
--- a/charts/dirk/templates/statefulset.yaml
+++ b/charts/dirk/templates/statefulset.yaml
@@ -84,6 +84,7 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            allowPrivilegeEscalation: {{ .Values.global.securityContext.allowPrivilegeEscalation | default false }}
             capabilities:
               drop:
                 - ALL
@@ -115,6 +116,7 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            allowPrivilegeEscalation: {{ .Values.global.securityContext.allowPrivilegeEscalation | default false }}
             capabilities:
               drop:
                 - ALL
@@ -166,6 +168,7 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            allowPrivilegeEscalation: {{ .Values.global.securityContext.allowPrivilegeEscalation | default false }}
             capabilities:
               drop:
                 - ALL

--- a/charts/dirk/values.yaml
+++ b/charts/dirk/values.yaml
@@ -120,6 +120,7 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+  # allowPrivilegeEscalation: false
 
 service:
   type: ClusterIP

--- a/charts/execution-beacon/values.yaml
+++ b/charts/execution-beacon/values.yaml
@@ -251,6 +251,7 @@ global:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 10000
+    allowPrivilegeEscalation: false
     capabilities:
       drop:
       - ALL

--- a/charts/lodestar/values.yaml
+++ b/charts/lodestar/values.yaml
@@ -52,6 +52,7 @@ securityContext:
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+  # allowPrivilegeEscalation: false
 
 service:
   type: ClusterIP

--- a/charts/mev-boost/values.yaml
+++ b/charts/mev-boost/values.yaml
@@ -25,6 +25,7 @@ global:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 10000
+    allowPrivilegeEscalation: false
     capabilities:
       drop:
       - ALL

--- a/charts/posmoni/values.yaml
+++ b/charts/posmoni/values.yaml
@@ -45,6 +45,7 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+  # allowPrivilegeEscalation: false
 
 service:
   type: ClusterIP

--- a/charts/validator-ejector/values.yaml
+++ b/charts/validator-ejector/values.yaml
@@ -125,6 +125,7 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+  # allowPrivilegeEscalation: false
 
 service:
   type: ClusterIP

--- a/charts/validator-kapi/values.yaml
+++ b/charts/validator-kapi/values.yaml
@@ -95,6 +95,7 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+  # allowPrivilegeEscalation: false
 
 service:
   type: ClusterIP

--- a/charts/validators/values.yaml
+++ b/charts/validators/values.yaml
@@ -19,6 +19,7 @@ global:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 10000
+    allowPrivilegeEscalation: false
     capabilities:
       drop:
       - ALL

--- a/charts/vouch/templates/statefulset.yaml
+++ b/charts/vouch/templates/statefulset.yaml
@@ -74,6 +74,7 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            allowPrivilegeEscalation: {{ .Values.global.securityContext.allowPrivilegeEscalation | default false }}
             capabilities:
               drop:
                 - ALL
@@ -104,6 +105,7 @@ spec:
             runAsUser: {{ .Values.global.securityContext.runAsUser | default 10000 }}
             fsGroup: {{ .Values.global.securityContext.fsGroup | default 10000 }}
             readOnlyRootFilesystem: {{ .Values.global.securityContext.readOnlyRootFilesystem | default true }}
+            allowPrivilegeEscalation: {{ .Values.global.securityContext.allowPrivilegeEscalation | default false }}
             capabilities:
               drop:
                 - ALL

--- a/charts/vouch/values.yaml
+++ b/charts/vouch/values.yaml
@@ -140,6 +140,7 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
+  # allowPrivilegeEscalation: false
 
 service:
   type: ClusterIP

--- a/charts/web3signer/values.yaml
+++ b/charts/web3signer/values.yaml
@@ -18,6 +18,7 @@ global:
     readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 10000
+    allowPrivilegeEscalation: false
     capabilities:
       drop:
       - ALL


### PR DESCRIPTION
QS Audit - Jan 2024
Impact: Low due to flag prevent pod escalating to root. 