### PR TITLE
Rolling out automountServiceAccountToken: false for lodestar

### DIFF
--- a/charts/lodestar/templates/statefulset.yaml
+++ b/charts/lodestar/templates/statefulset.yaml
@@ -19,6 +19,7 @@ spec:
       labels:
         {{- include "lodestar.selectorLabels" . | nindent 8 }}
     spec:
+      automountServiceAccountToken: false
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
QS Audit missed chart