### PR TITLE
[juno-node] Add SVC external traffic type.

### DIFF
--- a/charts/juno-node/Chart.yaml
+++ b/charts/juno-node/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: juno-chart
-version: 0.1.2
+version: 0.1.3
 appVersion: "1"
 description: A Helm chart for deploying Juno service
 maintainers:

--- a/charts/juno-node/templates/internal-alb.yaml
+++ b/charts/juno-node/templates/internal-alb.yaml
@@ -11,6 +11,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.rpc.clustertype }}
+  externalTrafficPolicy: Local
   ports:
   - port: {{ .Values.svc.rpc.port }}
     name: port-{{ .Values.svc.rpc.port }}
@@ -32,6 +33,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.wss.clustertype }}
+  externalTrafficPolicy: Local
   ports:
   - port: {{ .Values.svc.wss.port }}
     name: port-{{ .Values.svc.wss.port }}

--- a/charts/juno-node/templates/internal-alb.yaml
+++ b/charts/juno-node/templates/internal-alb.yaml
@@ -11,7 +11,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.rpc.clustertype }}
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: {{ default "Cluster" .Values.svc.externalTrafficPolicy }}
   ports:
   - port: {{ .Values.svc.rpc.port }}
     name: port-{{ .Values.svc.rpc.port }}
@@ -33,7 +33,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.wss.clustertype }}
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: {{ default "Cluster" .Values.svc.externalTrafficPolicy }}
   ports:
   - port: {{ .Values.svc.wss.port }}
     name: port-{{ .Values.svc.wss.port }}

--- a/charts/juno-node/templates/svc-wss.yaml
+++ b/charts/juno-node/templates/svc-wss.yaml
@@ -10,10 +10,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.wss.clustertype }}
-  sessionAffinity: ClientIP
-  sessionAffinityConfig:
-    clientIP:
-      timeoutSeconds: 30
+  externalTrafficPolicy: Local
   ports:
   - port: {{ .Values.svc.wss.port }}
     name: port-{{ .Values.svc.wss.port }}

--- a/charts/juno-node/templates/svc-wss.yaml
+++ b/charts/juno-node/templates/svc-wss.yaml
@@ -10,7 +10,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.wss.clustertype }}
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: {{ default "Cluster" .Values.svc.externalTrafficPolicy }}
   ports:
   - port: {{ .Values.svc.wss.port }}
     name: port-{{ .Values.svc.wss.port }}

--- a/charts/juno-node/templates/svc.yaml
+++ b/charts/juno-node/templates/svc.yaml
@@ -10,10 +10,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.rpc.clustertype }}
-  sessionAffinity: ClientIP
-  sessionAffinityConfig:
-    clientIP:
-      timeoutSeconds: 30
+  externalTrafficPolicy: Local
   ports:
   - port: {{ .Values.svc.rpc.port }}
     name: port-{{ .Values.svc.rpc.port }}

--- a/charts/juno-node/templates/svc.yaml
+++ b/charts/juno-node/templates/svc.yaml
@@ -10,7 +10,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.rpc.clustertype }}
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: {{ default "Cluster" .Values.svc.externalTrafficPolicy }}
   ports:
   - port: {{ .Values.svc.rpc.port }}
     name: port-{{ .Values.svc.rpc.port }}

--- a/charts/juno-node/templates/svc.yaml
+++ b/charts/juno-node/templates/svc.yaml
@@ -10,7 +10,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.rpc.clustertype }}
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
   ports:
   - port: {{ .Values.svc.rpc.port }}
     name: port-{{ .Values.svc.rpc.port }}

--- a/charts/juno-node/templates/svc.yaml
+++ b/charts/juno-node/templates/svc.yaml
@@ -10,7 +10,7 @@ metadata:
     cloud.google.com/neg: '{"ingress": true}'
 spec:
   type: {{ .Values.svc.rpc.clustertype }}
-  externalTrafficPolicy: Cluster
+  externalTrafficPolicy: Local
   ports:
   - port: {{ .Values.svc.rpc.port }}
     name: port-{{ .Values.svc.rpc.port }}

--- a/charts/juno-node/values.yaml
+++ b/charts/juno-node/values.yaml
@@ -85,6 +85,7 @@ serviceAccount:
 svc:
   globalStaticIpName: ""
   globalStaticInternalIpName: ""
+  externalTrafficPolicy: ""
   rpc:
     clustertype: ClusterIP     # Support: LoadBalancer, NodePort, ClusterIP
     port: "6060"


### PR DESCRIPTION
Added Juno Service traffic type. Values should be either Cluster or Local
`.Values.svc.externalTrafficPolicy` 
