### PR TITLE
fix: Chart pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   release:
@@ -32,7 +33,7 @@ jobs:
             helm dependency update "$dir";
           done
           helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add ethereum-helm-charts https://ethpandaops.github.io/ethereum-helm-charts 
+          helm repo add ethereum-helm-charts https://ethpandaops.github.io/ethereum-helm-charts
           helm repo add prometheus-charts https://prometheus-community.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
           helm repo add external-secrets https://charts.external-secrets.io
@@ -43,4 +44,5 @@ jobs:
           charts_dir: charts
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}" # The GitHub token of this repository
+          CR_SKIP_EXISTING: true
           CR_GENERATE_RELEASE_NOTES: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to Nethermind Helm Charts
+# Contributing
 
 The Nethermind infrastructure team is responsible for maintaining the Nethermind Helm charts. We welcome contributions from the community and are happy to review and merge pull requests. This document outlines the process for contributing to the Nethermind Helm charts.
 
-## Contributing
+## Before you begin
 
 When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
 

--- a/README.md
+++ b/README.md
@@ -2,42 +2,13 @@
 
 The list of helm charts forked and reworked from [StakeWise helm repository](https://github.com/stakewise/helm-charts), maintained and further developed by Nethermind team. Every chart is located in a separate folder and has the configuration parameters located in `values.yaml` file.
 
-## TL;DR
+## Usage
 
 ```bash
-$ helm repo add nethermindeth https://charts.nethermind.io
-$ helm install my-release nethermindeth/<chart-name>
+helm repo add nethermind https://nethermindeth.github.io/charts
+helm install my-release nethermind/<chart-name>
 ```
 
-## Before you begin
+## Contributing
 
-### Prerequisites
-
-- Kubernetes 1.23+
-- Helm 3
-- PV provisioner support in the underlying infrastructure for some charts
-
-### Setup a Kubernetes Cluster
-
-For setting up Kubernetes on cloud platforms or bare-metal servers refer to the
-Kubernetes [getting started guide](http://kubernetes.io/docs/getting-started-guides/).
-
-### Install Helm
-
-Helm is a tool for managing Kubernetes charts. Charts are packages of pre-configured Kubernetes resources.
-
-To install Helm, refer to the [Helm install guide](https://github.com/helm/helm#install) and ensure that the `helm`
-binary is in the `PATH` of your shell.
-
-### Using Helm
-
-Once you have installed the Helm client, you can deploy a charts located in this repository into a Kubernetes cluster.
-
-Please refer to the [Quick Start guide](https://helm.sh/docs/intro/quickstart/) if you wish to get running in just a few
-commands, otherwise the [Using Helm Guide](https://helm.sh/docs/intro/using_helm/) provides detailed instructions on how
-to use the Helm client to manage packages on your Kubernetes cluster.
-
-Useful Helm Client Commands:
-
-* Install a chart: `helm install my-release stakewise/<chart-name>`
-* Upgrade your application: `helm upgrade`
+Please see the [contributing guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
### Description

- Helm Chart Release workflow has been broken since PR #123 where the chart version was not bumped, this change will skip existing releases and allow the other charts to be pushed.